### PR TITLE
Correct the syntax for file attachments

### DIFF
--- a/generate_additional_files.py
+++ b/generate_additional_files.py
@@ -42,7 +42,7 @@ Stock-Id=gtk-dnd-multiple
 Selection=NotNone
 Extensions=nodirs;
 Dependencies=thunderbird;
-Separator=, 
+Separator=,
 """
 
 gettext.install(DOMAIN, PATH)


### PR DESCRIPTION
The sending of multiple files in nemo via thunderbird has been broken for a
while now. To reproduce, try to select multiple files in Nemo and select
send by mail.
The reason is, that the given syntax is not correct. Multiple file have
to be separated by only a colon, whereas the given separator also
includes a blank.

See also:
http://kb.mozillazine.org/Command_line_arguments_-_Thunderbird#Compose_new_mail_with_command_line

Removing the blank restores the functionality.

Tested in a freshly installed Linux Mint 16 with Nemo.
