### PR TITLE
use a relative symbolic link

### DIFF
--- a/usr/bin/cinnamon-remove-application
+++ b/usr/bin/cinnamon-remove-application
@@ -1,1 +1,1 @@
-/usr/lib/linuxmint/common/mint-remove-application.py
+../lib/linuxmint/common/mint-remove-application.py


### PR DESCRIPTION
This triggers the Lintian warning [source-contains-unsafe-symlink](https://lintian.debian.org/tags/source-contains-unsafe-symlink.html). However, since that symlink will just be copied into the final binary package, this error is kind of wrong. I'd still replace it with a relative link, I wouldn't know a reason to keep the absolute path inside the link. Otherwise just close this PR and add a Lintian override for this tag.