### PR TITLE
version.py: improve performance and update to Python 3 (v2)

### DIFF
--- a/usr/lib/linuxmint/common/version.py
+++ b/usr/lib/linuxmint/common/version.py
@@ -1,14 +1,15 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 
-import apt
+import shlex
+import subprocess
 import sys
 
 try:
-    cache = apt.Cache()
-    pkg = cache[sys.argv[1]]
-    if pkg.installed is not None:
-        print (pkg.installed.version)
+    (status, version) = subprocess.getstatusoutput("/usr/bin/dpkg-query -f '${Version}' -W %s" % shlex.quote(sys.argv[1]))
+    if status == 0 and version is not None:
+        print (version)
     else:
         print ("")
 except:
     print ("")
+


### PR DESCRIPTION
Improved version of #20.

version.py is called for example by mintupdate to get its package version for showing in its About dialog. The performance of version.py is such that it takes (on my system) almost two seconds for mintupdate's About dialog to appear. Other programs using this script would be similarly affected.

The proposed change improves performance (on my system going from almost to 2 seconds to just 1/10th of a second) by switching from apt.Cache() to call dpkg-query instead. All failure scenario's have been tested (missing arguments; too many arguments; invalid arguments; missing commands).

Also updated the script to Python 3.