### PR TITLE
Remove superfluous quotation marks in dialog texts

### DIFF
--- a/usr/lib/linuxmint/common/mint-remove-application.py
+++ b/usr/lib/linuxmint/common/mint-remove-application.py
@@ -33,9 +33,9 @@ class RemoveExecuter(threading.Thread):
         cmd = ["sudo", "/usr/sbin/synaptic", "--hide-main-window",
                "--non-interactive"]
         cmd.append("--progress-str")
-        cmd.append("\"" + _("Please wait, this can take some time") + "\"")
+        cmd.append(_("Please wait, this can take some time"))
         cmd.append("--finish-str")
-        cmd.append("\"" + _("Application removed successfully") + "\"")
+        cmd.append(_("Application removed successfully"))
         f = tempfile.NamedTemporaryFile()
         strbuffer = ""
         for pkg in self.packages:


### PR DESCRIPTION
Quotation marks around the texts in the dialogs appear odd to the user, as if you're quoting someone or you don't mean it sincerely. It just looks weird.

![image](https://user-images.githubusercontent.com/514461/35373419-fa2c3648-01a6-11e8-8106-b123ac698278.png)

![image](https://user-images.githubusercontent.com/514461/35373429-04e32218-01a7-11e8-8fce-b335e8ff59f0.png)
