### PR TITLE
Refactor mint-remove application to use xapp installer

### DIFF
--- a/usr/bin/mint-remove-application
+++ b/usr/bin/mint-remove-application
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-pkexec /usr/lib/linuxmint/common/mint-remove-application.py $1
+/usr/lib/linuxmint/common/mint-remove-application.py $1

--- a/usr/lib/linuxmint/common/mint-remove-application.py
+++ b/usr/lib/linuxmint/common/mint-remove-application.py
@@ -5,73 +5,74 @@ gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 
 import sys
-import string
 import os
 import gettext
-import mintcommon
 import subprocess
+
+from pathlib import Path
+from xapp.pkgCache import installer
 
 # i18n
 gettext.install("mint-common", "/usr/share/linuxmint/locale")
 
 class MintRemoveWindow:
-
     def __init__(self, desktopFile):
         self.desktopFile = desktopFile
-        (status, output) = subprocess.getstatusoutput("dpkg -S " + self.desktopFile)
-        package = output[:output.find(":")].split(",")[0]
-        if status != 0:
-            warnDlg = Gtk.MessageDialog(None, 0, Gtk.MessageType.WARNING, Gtk.ButtonsType.YES_NO, _("This menu item is not associated to any package. Do you want to remove it from the menu anyway?"))
-            warnDlg.get_widget_for_response(Gtk.ResponseType.YES).grab_focus()
-            warnDlg.vbox.set_spacing(10)
-            response = warnDlg.run()
-            if response == Gtk.ResponseType.YES:
-                print ("removing '%s'" % self.desktopFile)
-                os.system("rm -f '%s'" % self.desktopFile)
-                os.system("rm -f '%s.desktop'" % self.desktopFile)
-            warnDlg.destroy()
-            sys.exit(0)
 
-        warnDlg = Gtk.MessageDialog(None, 0, Gtk.MessageType.WARNING, Gtk.ButtonsType.OK_CANCEL, _("The following packages will be removed:"))
-        warnDlg.get_widget_for_response(Gtk.ResponseType.OK).grab_focus()
+        self.installer = installer.Installer().init(self.on_installer_ready)
+
+    def on_installer_ready(self):
+        pkg_name = None
+
+        pkg_name = self.get_apt_name()
+
+        if pkg_name == None:
+            pkg_name = self.get_fp_name()
+
+        if pkg_name == None:
+            self.do_no_packages_dialog()
+
+        pkginfo = self.installer.find_pkginfo(pkg_name)
+
+        if pkginfo and self.installer.pkginfo_is_installed(pkginfo):
+            self.installer.select_pkginfo(pkginfo, self.on_installer_ready_to_remove)
+        else:
+            self.do_no_packages_dialog()
+
+    def on_installer_ready_to_remove(self, task):
+        self.installer.execute_task(task, self.on_finished)
+
+    def do_no_packages_dialog(self):
+        warnDlg = Gtk.MessageDialog(None, 0, Gtk.MessageType.WARNING, Gtk.ButtonsType.YES_NO, _("This menu item is not associated to any package. Do you want to remove it from the menu anyway?"))
+        warnDlg.get_widget_for_response(Gtk.ResponseType.YES).grab_focus()
         warnDlg.vbox.set_spacing(10)
 
-        treeview = Gtk.TreeView()
-        column1 = Gtk.TreeViewColumn(_("Packages to be removed"))
-        renderer = Gtk.CellRendererText()
-        column1.pack_start(renderer, False)
-        column1.add_attribute(renderer, "text", 0)
-        treeview.append_column(column1)
-
-        packages = []
-        model = Gtk.ListStore(str)
-        dependenciesString = subprocess.getoutput("apt-get -s -q remove " + package + " | grep Remv")
-        dependencies = dependenciesString.split("\n")
-        for dependency in dependencies:
-            dependency = dependency.replace("Remv ", "")
-            model.append([dependency])
-            packages.append(dependency.split()[0])
-        treeview.set_model(model)
-        treeview.show()
-
-        scrolledwindow = Gtk.ScrolledWindow()
-        scrolledwindow.set_shadow_type(Gtk.ShadowType.ETCHED_OUT)
-        scrolledwindow.set_size_request(150, 150)
-        scrolledwindow.add(treeview)
-        scrolledwindow.show()
-
-        warnDlg.get_content_area().add(scrolledwindow)
-
-        self.apt = mintcommon.APT(warnDlg)
-
         response = warnDlg.run()
-        if response == Gtk.ResponseType.OK:
-            self.apt.set_finished_callback(self.on_finished)
-            self.apt.remove_packages(packages)
-        elif response == Gtk.ResponseType.CANCEL:
-            sys.exit(0)
+
+        if response == Gtk.ResponseType.YES:
+            print ("removing '%s'" % self.desktopFile)
+            os.system("rm -f '%s'" % self.desktopFile)
+            os.system("rm -f '%s.desktop'" % self.desktopFile)
 
         warnDlg.destroy()
+        sys.exit(0)
+
+    def get_apt_name(self):
+        (status, output) = subprocess.getstatusoutput("dpkg -S " + self.desktopFile)
+        package = output[:output.find(":")].split(",")[0]
+
+        if status == 0:
+            return package
+        else:
+            return None
+
+    def get_fp_name(self):
+        path = Path(self.desktopFile)
+
+        if "flatpak" not in path.parts:
+            return None
+
+        return path.stem
 
     def on_finished(self, transaction=None, exit_state=None):
         sys.exit(0)


### PR DESCRIPTION
(depends on https://github.com/linuxmint/python-xapp/pull/6)

Allows the script to uninstall both apt and flatpak packages