### PR TITLE
fix runtime dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,8 +7,13 @@ Standards-Version: 3.9.5
 
 Package: mint-common
 Architecture: all
-Depends: python (>= 2.4), python (<< 3),
-         python-gi,
+Depends: python,
+         python3,
+         python3-aptdaemon,
+         python3-aptdaemon.gtk3widgets,
+         python3-gi,
+         gir1.2-gtk-3.0,
+         gir1.2-xapp-1.0,
          mint-translations,
          libgtk3-perl
          ${misc:Depends},


### PR DESCRIPTION
- both python 2 and 3 are needed due to mix of them among scripts here
- aptdaemon/gtk/xapp are needed because mintsources tries to import mintcommon and fails
- python3-gi replaces python-gi as only python 3 scripts have "import gi"