### PR TITLE
mintcommon v2

### DIFF
--- a/test
+++ b/test
@@ -1,5 +1,5 @@
-#!/bin/bash
+#!/bin/sh
 
 sudo rm -rf /usr/lib/linuxmint/common
+sudo rm -rf /usr/lib/python3/dist-packages/mintcommon
 sudo cp -R usr /
-

--- a/usr/bin/mint-remove-application
+++ b/usr/bin/mint-remove-application
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 pkexec /usr/lib/linuxmint/common/mint-remove-application.py $1

--- a/usr/lib/linuxmint/common/additionalfiles.py
+++ b/usr/lib/linuxmint/common/additionalfiles.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 
 import os
 import gettext

--- a/usr/lib/linuxmint/common/generate_additional_files.py
+++ b/usr/lib/linuxmint/common/generate_additional_files.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 
 import os
 import gettext
@@ -8,7 +8,7 @@ PATH = "/usr/share/linuxmint/locale"
 
 
 def generate(filename, prefix, name, comment, suffix):
-    print "HERE"
+    print("HERE")
     os.environ['LANG'] = "en_US.UTF-8"
     gettext.install(DOMAIN, PATH)
     desktopFile = open(filename, "w")

--- a/usr/lib/linuxmint/common/mint-remove-application.py
+++ b/usr/lib/linuxmint/common/mint-remove-application.py
@@ -1,15 +1,15 @@
 #!/usr/bin/python3
 
+import gettext
+import os
+import subprocess
+import sys
+
 import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 
-import sys
-import string
-import os
-import gettext
-import mintcommon
-import subprocess
+import mintcommon.aptdaemon
 
 # i18n
 gettext.install("mint-common", "/usr/share/linuxmint/locale")
@@ -64,7 +64,7 @@ class MintRemoveWindow:
 
         warnDlg.get_content_area().add(scrolledwindow)
 
-        self.apt = mintcommon.APT(warnDlg)
+        self.apt = mintcommon.aptdaemon.APT(warnDlg)
 
         response = warnDlg.run()
         if response == Gtk.ResponseType.OK:

--- a/usr/lib/python3/dist-packages/mintcommon/aptdaemon.py
+++ b/usr/lib/python3/dist-packages/mintcommon/aptdaemon.py
@@ -1,0 +1,122 @@
+__version__ = "1.0.0"
+
+import gi
+gi.require_version('Gtk', '3.0')
+gi.require_version('GdkX11', '3.0') # Needed to get xid
+gi.require_version('XApp', '1.0')
+from gi.repository import Gtk, XApp
+
+import aptdaemon.client
+import aptdaemon.enums
+import aptdaemon.errors
+from aptdaemon.gtk3widgets import AptErrorDialog, AptConfirmDialog, AptProgressDialog
+
+class APT(object):
+
+    def __init__(self, parent_window=None):
+        self.parent_window = parent_window
+        self.progress_callback = None
+        self.finished_callback = None
+        self.error_callback = None
+        self.cancelled_callback = None
+
+    def set_progress_callback(self, progress_callback):
+        self.progress_callback = progress_callback
+
+    def set_finished_callback(self, finished_callback):
+        self.finished_callback = finished_callback
+
+    def set_error_callback(self, error_callback):
+        self.error_callback = error_callback
+
+    def set_cancelled_callback(self, cancelled_callback):
+        self.cancelled_callback = cancelled_callback
+
+    def update_cache(self):
+        aptdaemon_client = aptdaemon.client.AptClient()
+        update_transaction = aptdaemon_client.update_cache()
+        self._run_transaction(update_transaction)
+
+    def install_file(self, path):
+        aptdaemon_client = aptdaemon.client.AptClient()
+        aptdaemon_client.install_file(path, force=True, wait=False, reply_handler=self._simulate_trans, error_handler=self._on_error)
+
+    def install_packages(self, packages):
+        aptdaemon_client = aptdaemon.client.AptClient()
+        aptdaemon_client.install_packages(packages, reply_handler=self._simulate_trans, error_handler=self._on_error)
+
+    def remove_packages(self, packages):
+        aptdaemon_client = aptdaemon.client.AptClient()
+        aptdaemon_client.remove_packages(packages, reply_handler=self._simulate_trans, error_handler=self._on_error)
+
+    def _run_transaction(self, transaction):
+        if self.progress_callback is None:
+            dia = AptProgressDialog(transaction, parent=self.parent_window)
+            dia.run(close_on_finished=True, show_error=True, reply_handler=lambda: True, error_handler=self._on_error)
+            transaction.connect("finished", self._on_finish)
+        else:
+            AptDaemonTransaction(transaction, self.progress_callback, self.finished_callback, self.error_callback, self.parent_window)
+
+    def _simulate_trans(self, trans):
+        trans.simulate(reply_handler=lambda: self._confirm_deps(trans), error_handler=self._on_error)
+
+    def _confirm_deps(self, trans):
+        try:
+            if [pkgs for pkgs in trans.dependencies if pkgs]:
+                dia = AptConfirmDialog(trans, parent=self.parent_window)
+                res = dia.run()
+                dia.hide()
+                if res != Gtk.ResponseType.OK:
+                    if self.cancelled_callback is not None:
+                        self.cancelled_callback()
+                    return
+            self._run_transaction(trans)
+        except Exception as e:
+            print(e)
+
+    def _on_error(self, error):
+        if isinstance(error, aptdaemon.errors.NotAuthorizedError):
+            # Silently ignore auth failures
+            return
+        elif not isinstance(error, aptdaemon.errors.TransactionFailed):
+            # Catch internal errors of the client
+            error = aptdaemon.errors.TransactionFailed(aptdaemon.enums.ERROR_UNKNOWN, str(error))
+        dia = AptErrorDialog(error)
+        dia.run()
+        dia.hide()
+
+    def _on_finish(self, transaction, exit_state):
+        if self.finished_callback is not None:
+            self.finished_callback(transaction, exit_state)
+
+class AptDaemonTransaction():
+
+    def __init__(self, transaction, progress_callback, finished_callback, error_callback, parent_window):
+        self.progress_callback = progress_callback
+        self.finished_callback = finished_callback
+        self.error_callback = error_callback
+        self.transaction = transaction
+        self.parent_window = parent_window
+        transaction.set_debconf_frontend("gnome")
+        transaction.connect("progress-changed", self.on_transaction_progress)
+        # transaction.connect("cancellable-changed", self.on_driver_changes_cancellable_changed)
+        transaction.connect("finished", self.on_transaction_finish)
+        transaction.connect("error", self.on_transaction_error)
+        transaction.run()
+
+    def on_transaction_progress(self, transaction, progress):
+        if self.progress_callback is not None:
+            self.progress_callback(progress)
+        if self.parent_window is not None:
+            XApp.set_window_progress(self.parent_window, progress)
+
+    def on_transaction_error(self, transaction, error_code, error_details):
+        if self.error_callback is not None:
+            self.error_callback(error_code, error_details)
+        if self.parent_window is not None:
+            XApp.set_window_progress(self.parent_window, 0)
+
+    def on_transaction_finish(self, transaction, exit_state):
+        if (exit_state == aptdaemon.enums.EXIT_SUCCESS):
+            if self.finished_callback is not None:
+                self.finished_callback(transaction, exit_state)

--- a/usr/lib/python3/dist-packages/mintcommon/installer/__init__.py
+++ b/usr/lib/python3/dist-packages/mintcommon/installer/__init__.py
@@ -2,4 +2,4 @@ __version__ = "2.0.0"
 
 """Collection of classes shared by Mint packages."""
 
-__all__ = ["aptdaemon", "installer"]
+__all__ = ["cache", "installer", "_apt", "_flatpak", "dialogs", "misc"]

--- a/usr/lib/python3/dist-packages/mintcommon/installer/_apt.py
+++ b/usr/lib/python3/dist-packages/mintcommon/installer/_apt.py
@@ -1,0 +1,316 @@
+import time
+import threading
+import apt
+
+import gi
+gi.require_version('AppStream', '1.0')
+gi.require_version('Gtk', '3.0')
+gi.require_version('Gdk', '3.0')
+from gi.repository import GObject, Gtk
+
+import aptdaemon.client
+from aptdaemon.gtk3widgets import AptErrorDialog, AptProgressDialog
+import aptdaemon.errors
+
+from .pkgInfo import AptPkgInfo
+from .dialogs import ChangesConfirmDialog
+
+# List of packages which are either broken or do not install properly in mintinstall
+BROKEN_PACKAGES = ['pepperflashplugin-nonfree']
+
+# List extra packages that aren't necessarily marked in their control files, but
+# we know better...
+CRITICAL_PACKAGES = ["mint-common", "mint-meta-core", "mintdesktop"]
+
+def capitalize(string):
+    if len(string) > 1:
+        return (string[0].upper() + string[1:])
+
+    return (string)
+
+_apt_cache = None
+_apt_cache_lock = threading.Lock()
+_as_pool = None
+
+def get_apt_cache(full=False):
+    global _apt_cache
+
+    if full or (not _apt_cache):
+        with _apt_cache_lock:
+            _apt_cache = apt.Cache()
+
+    return _apt_cache
+
+def add_prefix(name):
+    return "apt:%s" % (name)
+
+def make_pkg_hash(apt_pkg):
+    if not isinstance(apt_pkg, apt.Package):
+        raise TypeError("apt.make_pkg_hash_make must receive apt.Package, not %s" % type(apt_pkg))
+
+    return add_prefix(apt_pkg.name)
+
+def process_full_apt_cache(cache):
+    apt_time = time.time()
+    apt_cache = get_apt_cache()
+
+    sections = {}
+
+    keys = apt_cache.keys()
+
+    for key in keys:
+        name = apt_cache[key].name
+
+        if name.startswith("lib") and not name.startswith(("libreoffice", "librecad", "libk3b7", "libimage-exiftool-perl")):
+            continue
+        if name.endswith(":i386") and name != "steam:i386":
+            continue
+        if name.endswith("-dev"):
+            continue
+        if name.endswith("-dbg"):
+            continue
+        if name.endswith("-doc"):
+            continue
+        if name.endswith("-common"):
+            continue
+        if name.endswith("-data"):
+            continue
+        if "-locale-" in name:
+            continue
+        if "-l10n-" in name:
+            continue
+        if name.endswith("-dbgsym"):
+            continue
+        if name.endswith("l10n"):
+            continue
+        if name.endswith("-perl"):
+            continue
+        if ":" in name and name.split(":")[0] in keys:
+            continue
+
+        pkg = apt_cache[key]
+
+        pkg_hash = make_pkg_hash(pkg)
+
+        if pkg.section:
+            section_string = pkg.section
+
+            if "/" in section_string:
+                section = section_string.split("/")[1]
+            else:
+                section = section_string
+
+        try:
+            sections[section].append(pkg_hash)
+        except Exception:
+            sections[section] = []
+            sections[section].append(pkg_hash)
+
+        cache[pkg_hash] = AptPkgInfo(pkg_hash, pkg)
+
+    print('MintInstall: Processing APT packages for cache took %0.3f ms' % ((time.time() - apt_time) * 1000.0))
+
+    return cache, sections
+
+# def initialize_appstream():
+#     global _as_pool
+
+#     if _as_pool == None:
+#         pool = AppStream.Pool()
+#         pool.set_cache_flags(AppStream.CacheFlags.NONE)
+#         pool.load()
+#         _as_pool = pool
+
+def search_for_pkginfo_apt_pkg(pkginfo):
+    name = pkginfo.name
+
+    apt_cache = get_apt_cache()
+
+    try:
+        return apt_cache[name]
+    except:
+        return None
+
+def find_pkginfo(cache, string):
+    try:
+        pkginfo = cache[add_prefix(string)]
+    except:
+        pkginfo = None
+
+    return pkginfo
+
+def pkginfo_is_installed(pkginfo):
+    global _apt_cache_lock
+    apt_cache = get_apt_cache()
+
+    with _apt_cache_lock:
+        try:
+            return apt_cache[pkginfo.name].installed != None
+        except:
+            return False
+
+def select_packages(task):
+    thread = threading.Thread(target=_calculate_apt_changes, args=(task,))
+    thread.start()
+
+def _is_critical_package(pkg):
+    try:
+        if pkg.essential or pkg.versions[0].priority == "required" or pkg.name in CRITICAL_PACKAGES:
+            return True
+
+        return False
+    except Exception:
+        return False
+
+def _calculate_apt_changes(task):
+    global _apt_cache_lock
+    apt_cache = get_apt_cache()
+
+    with _apt_cache_lock:
+        apt_cache.clear()
+
+        print("MintInstall: Calculating changes required for APT package: %s" % task.pkginfo.name)
+
+        pkginfo = task.pkginfo
+
+        aptpkg = apt_cache[pkginfo.name]
+
+        try:
+            if aptpkg.is_installed:
+                aptpkg.mark_delete(True, True)
+            else:
+                aptpkg.mark_install()
+        except:
+            if aptpkg.name not in BROKEN_PACKAGES:
+                BROKEN_PACKAGES.append(aptpkg.name)
+
+        changes = apt_cache.get_changes()
+
+        for pkg in changes:
+            if pkg.marked_install:
+                task.to_install.append(pkg.name)
+            elif pkg.marked_upgrade:
+                task.to_update.append(pkg.name)
+            elif pkg.marked_delete:
+                task.to_remove.append(pkg.name)
+
+        task.download_size = apt_cache.required_download
+
+        space = apt_cache.required_space
+
+        if space < 0:
+            task.freed_size = space * -1
+            task.install_size = 0
+        else:
+            task.freed_size = 0
+            task.install_size = space
+
+        for pkg_name in task.to_remove:
+            if _is_critical_package(apt_cache[pkg_name]):
+                print("MintInstall: apt - cannot remove critical package: %s" % pkg_name)
+                task.info_ready_status = task.STATUS_FORBIDDEN
+
+        if aptpkg.name in BROKEN_PACKAGES:
+            print("MintInstall: apt- cannot execute task, package is broken: %s" % aptpkg.name)
+            task.info_ready_status = task.STATUS_BROKEN
+
+        print("For install:", task.to_install)
+        print("For removal:", task.to_remove)
+        print("For upgrade:", task.to_update)
+
+        if task.info_ready_status not in (task.STATUS_FORBIDDEN, task.STATUS_BROKEN):
+            task.info_ready_status = task.STATUS_OK
+            task.execute = execute_transaction
+
+    GObject.idle_add(task.info_ready_callback, task)
+
+def sync_cache_installed_states():
+    get_apt_cache(full=True)
+
+def execute_transaction(task):
+    if task.client_progress_cb != None:
+        task.has_window = True
+
+    task.transaction = MetaTransaction(task)
+
+class MetaTransaction():
+    def __init__(self, task):
+        self.apt_client = aptdaemon.client.AptClient()
+        self.task = task
+        self.apt_transaction = None
+
+        if task.type == "remove":
+            self.apt_client.remove_packages([task.pkginfo.name],
+                                            reply_handler=self._calculate_changes,
+                                            error_handler=self._on_error) # dbus.DBusException
+        else:
+            self.apt_client.install_packages([task.pkginfo.name],
+                                             reply_handler=self._calculate_changes,
+                                             error_handler=self._on_error) # dbus.DBusException
+
+    def _calculate_changes(self, apt_transaction):
+        self.apt_transaction = apt_transaction
+        self.apt_transaction.set_debconf_frontend("gnome")
+
+        self.apt_transaction.simulate(reply_handler=self._confirm_changes,
+                                      error_handler=self._on_error) # aptdaemon.errors.TransactionFailed, dbus.DBusException
+
+    def _confirm_changes(self):
+        try:
+            if [pkgs for pkgs in self.apt_transaction.dependencies if pkgs]:
+                dia = ChangesConfirmDialog(self.apt_transaction, self.task)
+                res = dia.run()
+                dia.hide()
+                if res != Gtk.ResponseType.OK:
+                    GObject.idle_add(self.task.finished_cleanup_cb, self.task)
+                    return
+            self._run_transaction()
+        except Exception as e:
+            print(e)
+
+    def _on_error(self, error):
+        if self.apt_transaction.error_code == "error-not-authorized":
+            # Silently ignore auth failures
+
+            self.task.error_message = None # Should already be none, but this is a reminder
+            return
+        elif not isinstance(error, aptdaemon.errors.TransactionFailed):
+            # Catch internal errors of the client
+            error = aptdaemon.errors.TransactionFailed(aptdaemon.enums.ERROR_UNKNOWN,
+                                                       str(error))
+
+        if self.task.progress_state != self.task.PROGRESS_STATE_FAILED:
+            self.task.progress_state = self.task.PROGRESS_STATE_FAILED
+
+            self.task.error_message = self.apt_transaction.error_details
+
+            dia = AptErrorDialog(error)
+            dia.run()
+            dia.hide()
+            GObject.idle_add(self.task.error_cleanup_cb, self.task)
+
+    def _run_transaction(self):
+        self.apt_transaction.connect("finished", self.on_transaction_finished)
+
+        if self.task.has_window:
+            self.apt_transaction.connect("progress-changed", self.on_transaction_progress)
+            self.apt_transaction.connect("error", self.on_transaction_error)
+            self.apt_transaction.run(reply_handler=lambda: None, error_handler=self._on_error)
+        else:
+            progress_window = AptProgressDialog(self.apt_transaction)
+            progress_window.run(show_error=False, error_handler=self._on_error)
+
+    def on_transaction_progress(self, apt_transaction, progress):
+        if not apt_transaction.error:
+            self.task.client_progress_cb(self.task.pkginfo, progress, False)
+
+    def on_transaction_error(self, apt_transaction, error_code, error_details):
+        if self.task.progress_state != self.task.PROGRESS_STATE_FAILED:
+            self._on_error(apt_transaction.error)
+
+    def on_transaction_finished(self, apt_transaction, exit_state):
+        # finished signal is always called whether successful or not
+        # Only call here if we succeeded, to prevent multiple calls
+        if (exit_state == aptdaemon.enums.EXIT_SUCCESS) or apt_transaction.error_code == "error-not-authorized":
+            self.task.progress_state = self.task.PROGRESS_STATE_FINISHED
+            GObject.idle_add(self.task.finished_cleanup_cb, self.task)

--- a/usr/lib/python3/dist-packages/mintcommon/installer/_flatpak.py
+++ b/usr/lib/python3/dist-packages/mintcommon/installer/_flatpak.py
@@ -1,0 +1,1092 @@
+import time
+import threading
+import math
+from pathlib import Path
+import subprocess
+import requests
+import tempfile
+import os
+
+import gi
+gi.require_version('AppStream', '1.0')
+from gi.repository import AppStream, GLib, GObject, Gtk, Gio
+
+try:
+    gi.require_version('Flatpak', '1.0')
+    from gi.repository import Flatpak
+except:
+    pass
+
+from .pkgInfo import FlatpakPkgInfo
+from . import dialogs
+from .dialogs import ChangesConfirmDialog, FlatpakProgressWindow
+from .misc import debug
+
+class FlatpakRemoteInfo():
+    def __init__(self, remote):
+        self.name = remote.get_name()
+        self.title = remote.get_title()
+        self.url = remote.get_url()
+        self.disabled = remote.get_disabled()
+        self.noenumerate = remote.get_noenumerate()
+
+        if not self.title or self.title == "":
+            self.title = self.name.capitalize()
+
+_fp_sys = None
+
+_as_pool_lock = threading.Lock()
+_as_pools = {} # keyed to remote name
+
+def get_fp_sys():
+    global _fp_sys
+
+    if _fp_sys == None:
+        _fp_sys = Flatpak.Installation.new_system(None)
+
+    return _fp_sys
+
+ALIASES = {
+    "org.gnome.Weather" : "org.gnome.Weather.Application"
+}
+
+def make_pkg_hash(ref):
+    if not isinstance(ref, Flatpak.Ref):
+        raise TypeError("flatpak.make_pkg_hash() must receive FlatpakRef, not %s" % type(ref))
+
+    try:
+        return "fp:%s:%s" % (ref.get_origin(), ref.format_ref())
+    except Exception:
+        return "fp:%s:%s" % (ref.get_remote_name(), ref.format_ref())
+
+def _get_remote_name_by_url(fp_sys, url):
+    name = None
+
+    try:
+        remotes = fp_sys.list_remotes()
+    except GLib.Error:
+        remotes = []
+
+    for remote in remotes:
+        if remote.get_url() == url:
+            name = remote.get_name()
+
+    return name
+
+def _get_file_timestamp(gfile):
+    try:
+        info = gfile.query_info("time::modified", Gio.FileQueryInfoFlags.NONE, None)
+
+        return info.get_attribute_uint64("time::modified")
+    except GLib.Error as e:
+        if e.code != Gio.IOErrorEnum.NOT_FOUND:
+            print("MintInstall: flatpak - could not get time::modified from file %s" % gfile.get_path())
+        return 0
+
+def _should_update_appstream_data(fp_sys, remote, arch):
+    ret = False
+
+    current_timestamp = _get_file_timestamp(remote.get_appstream_timestamp(arch))
+
+    try:
+        if fp_sys.update_remote_sync(remote.get_name(), None):
+            print("MintInstall: flatpak - metadata for remote '%s' has been updated. Comparing appstream timestamps..." % remote.get_name())
+
+            new_timestamp = _get_file_timestamp(remote.get_appstream_timestamp(arch))
+
+            if (new_timestamp > current_timestamp) or (current_timestamp == 0):
+                ret = True
+    except GLib.Error as e:
+        print("MintInstall: flatpak - could not update metadata for remote '%s': %s" % (remote.get_name(), e.message))
+
+    return ret
+
+def _process_remote(cache, fp_sys, remote, arch):
+    remote_name = remote.get_name()
+
+    if remote.get_disabled():
+        print("MintInstall: flatpak - remote '%s' is disabled, skipping" % remote_name)
+        return
+
+    remote_url = remote.get_url()
+
+    if _should_update_appstream_data(fp_sys, remote, arch):
+        print("MintInstall: flatpak - new appstream data available for remote '%s', fetching..." % remote_name)
+
+        try:
+            fp_sys.update_appstream_sync(remote_name, arch, None)
+        except GLib.Error:
+            # Not fatal..
+            pass
+    else:
+        print("MintInstall: flatpak - no new appstream data for remote '%s', skipping download" % remote_name)
+
+    # get_noenumerate indicates whether a remote should be used to list applications.
+    # Instead, they're intended for single downloads (via .flatpakref files)
+    if remote.get_noenumerate():
+        print("MintInstall: flatpak - remote '%s' is marked as no-enumerate skipping package listing" % remote_name)
+        return
+
+    try:
+        for ref in fp_sys.list_remote_refs_sync(remote_name, None):
+            if ref.get_kind() != Flatpak.RefKind.APP:
+                continue
+
+            if ref.get_arch() != arch:
+                continue
+
+            _add_package_to_cache(cache, ref, remote_url, False)
+    except GLib.Error as e:
+        print(e.message)
+
+def _add_package_to_cache(cache, ref, remote_url, installed):
+    pkg_hash = make_pkg_hash(ref)
+
+    try:
+        remote_name = ref.get_remote_name()
+    except Exception:
+        remote_name = ref.get_origin()
+
+    try:
+        pkginfo = cache[pkg_hash]
+
+        if installed:
+            pkginfo.installed = installed
+    except KeyError:
+        pkginfo = FlatpakPkgInfo(pkg_hash, remote_name, ref, remote_url, installed)
+        cache[pkg_hash] = pkginfo
+
+    return pkginfo
+
+def process_full_flatpak_installation(cache):
+    fp_time = time.time()
+
+    arch = Flatpak.get_default_arch()
+    fp_sys = get_fp_sys()
+
+    flatpak_remote_infos = {}
+
+    try:
+        for remote in fp_sys.list_remotes():
+            _process_remote(cache, fp_sys, remote, arch)
+
+            remote_name = remote.get_name()
+
+            try:
+                for ref in fp_sys.list_installed_refs_by_kind(Flatpak.RefKind.APP, None):
+                    # All remotes will see installed refs, but the installed refs will always
+                    # report their correct origin, so only add installed refs when they match the remote.
+                    if ref.get_origin() == remote_name:
+                        _add_package_to_cache(cache, ref, remote.get_url(), True)
+            except GLib.Error as e:
+                print(e.message)
+
+            flatpak_remote_infos[remote_name] = FlatpakRemoteInfo(remote)
+
+    except GLib.Error as e:
+        print("MintInstall: flatpak - could not get remote list", e.message)
+        cache = {}
+
+    print('MintInstall: Processing Flatpaks for cache took %0.3f ms' % ((time.time() - fp_time) * 1000.0))
+
+    return cache, flatpak_remote_infos
+
+def _load_appstream_pool(pools, remote):
+    pool = AppStream.Pool()
+    pool.add_metadata_location(remote.get_appstream_dir().get_path())
+    pool.set_cache_flags(AppStream.CacheFlags.NONE)
+    pool.load()
+    pools[remote.get_name()] = pool
+
+def initialize_appstream():
+    thread = threading.Thread(target=_initialize_appstream_thread)
+    thread.start()
+
+def _initialize_appstream_thread():
+    fp_sys = get_fp_sys()
+
+    global _as_pools
+    global _as_pool_lock
+
+    with _as_pool_lock:
+        _as_pools = {}
+
+        try:
+            for remote in fp_sys.list_remotes():
+                _load_appstream_pool(_as_pools, remote)
+        except GLib.Error:
+            print("MintInstall: Could not initialize appstream components for flatpaks")
+
+def search_for_pkginfo_as_component(pkginfo):
+    name = pkginfo.name
+
+    comps = []
+
+    global _as_pools
+    global _as_pool_lock
+
+    with _as_pool_lock:
+        try:
+            pool = _as_pools[pkginfo.remote]
+        except Exception:
+            return None
+
+        comps = pool.get_components_by_id(name + ".desktop")
+
+        if comps == []:
+            if name in ALIASES.keys():
+                comps = pool.get_components_by_id(ALIASES[name] + ".desktop")
+            else:
+                comps = pool.get_components_by_id(name)
+
+    if len(comps) > 0:
+        return comps[0]
+    else:
+        return None
+
+def _is_ref_installed(fp_sys, ref):
+    try:
+        iref = fp_sys.get_installed_ref(ref.get_kind(),
+                                        ref.get_name(),
+                                        ref.get_arch(),
+                                        ref.get_branch(),
+                                        None)
+
+        if iref:
+            return True
+    except GLib.Error:
+        pass
+    except AttributeError: # bad/null ref
+        pass
+
+    return False
+
+def _get_remote_sizes(fp_sys, remote, ref):
+    # Since 0.11.4, this info is part of FlatpakRemoteRef
+    # dl_s = ref.props.download_size
+    # inst_s = ref.props.installed_size
+    # But it appears to always contain identical dl and installed sizes,
+    # so avoid it for now.
+
+    try:
+        success, dl_s, inst_s = fp_sys.fetch_remote_size_sync(remote,
+                                                              ref,
+                                                              None)
+    except GLib.Error as e:
+        print(e.message)
+        # Not fatal?
+        dl_s = 0
+        inst_s = 0
+
+    return dl_s, inst_s
+
+def _get_installed_size(fp_sys, ref):
+    if isinstance(ref, Flatpak.InstalledRef):
+        return ref.get_installed_size()
+    else:
+        try:
+            iref = fp_sys.get_installed_ref(ref.get_kind(),
+                                            ref.get_name(),
+                                            ref.get_arch(),
+                                            ref.get_branch(),
+                                            None)
+            return iref.get_installed_size()
+        except GLib.Error as e:
+            print(e.message)
+            # This isn't fatal I guess?
+            return 0
+
+def _add_to_list(ref_list, ref):
+    ref_str = ref.format_ref()
+
+    for existing_ref in ref_list:
+        if ref_str == existing_ref.format_ref():
+            debug("Skipping %s, already added to task" % ref_str)
+            return
+
+    ref_list.append(ref)
+
+def _add_ref_to_task(fp_sys, task, ref, needs_update=False):
+    if task.type == "install":
+        if needs_update:
+            _add_to_list(task.to_update, ref)
+        else:
+            _add_to_list(task.to_install, ref)
+
+        dl_s, inst_s = _get_remote_sizes(fp_sys, ref.get_remote_name(), ref)
+
+        task.download_size += dl_s
+        task.install_size += inst_s
+    elif task.type == "remove":
+        _add_to_list(task.to_remove, ref)
+        task.freed_size += _get_installed_size(fp_sys, ref)
+    else:
+        _add_to_list(task.to_update, ref)
+
+        current_inst_s = _get_installed_size(fp_sys, ref)
+        remote_dl_s, remote_inst_s = _get_remote_sizes(fp_sys, ref.get_remote_name(), ref)
+
+        task.download_size += remote_dl_s
+
+        if current_inst_s < remote_inst_s:
+            task.install_size += remote_inst_s - current_inst_s
+        else:
+            task.freed_size += current_inst_s - remote_inst_s
+
+def _find_remote_ref_from_list(fp_sys, remote_name, basic_ref, nofail=False):
+    remote_ref = None
+
+    all_refs = fp_sys.list_remote_refs_sync(remote_name, None)
+
+    ref_str = basic_ref.format_ref()
+
+    for ref in all_refs:
+        if ref_str == ref.format_ref():
+            remote_ref = ref
+            break
+
+    if remote_ref == None:
+        try:
+            remote_ref = fp_sys.fetch_remote_ref_sync(remote_name,
+                                                      basic_ref.get_kind(),
+                                                      basic_ref.get_name(),
+                                                      basic_ref.get_arch(),
+                                                      basic_ref.get_branch(),
+                                                      None)
+        except GLib.Error as e:
+            if nofail:
+                remote_ref = Flatpak.RemoteRef(remote_name=remote_name,
+                                               kind=basic_ref.get_kind(),
+                                               arch=basic_ref.get_arch(),
+                                               branch=basic_ref.get_branch(),
+                                               name=basic_ref.get_name(),
+                                               commit=basic_ref.get_commit(),
+                                               collection_id=basic_ref.get_collection_id())
+    return remote_ref
+
+def _get_runtime_ref(fp_sys, remote_name, ref):
+    runtime_ref = None
+    ref_string = None
+
+    try:
+        # Since 0.11.4 a FlatpakRemoteRef contains its metadata, so this
+        # query is unnecessary.
+        try:
+            meta = ref.props.metadata
+
+            if meta == None:
+                raise AttributeError
+        except AttributeError:
+            meta = fp_sys.fetch_remote_metadata_sync(remote_name, ref, None)
+
+        keyfile = GLib.KeyFile.new()
+
+        data = meta.get_data().decode()
+
+        keyfile.load_from_data(data, len(data), GLib.KeyFileFlags.NONE)
+
+        runtime = keyfile.get_string("Application", "runtime")
+        basic_ref = Flatpak.Ref.parse("runtime/%s" % runtime)
+
+        ref_string = basic_ref.format_ref() # for error reporting only
+
+        print("Looking for %s in %s" % (ref_string, remote_name))
+
+        # prefer the same-remote's runtimes
+        try:
+            runtime_ref = _find_remote_ref_from_list(fp_sys, remote_name, basic_ref)
+
+            if runtime_ref:
+                print("Found runtime ref '%s' in remote %s" % (runtime_ref.format_ref(), remote_name))
+        except GLib.Error:
+            pass
+        # if nothing is found, check other remotes
+        if runtime_ref == None:
+            for other_remote in fp_sys.list_remotes():
+                other_remote_name = other_remote.get_name()
+
+                if other_remote_name == remote_name:
+                    continue
+
+                print("Looking for %s in alternate remote %s" % (ref_string, other_remote_name))
+
+                try:
+                    runtime_ref = _find_remote_ref_from_list(fp_sys, other_remote_name, basic_ref)
+                except GLib.Error:
+                    continue
+
+                if runtime_ref:
+                    print("Found runtime ref '%s' in remote %s" % (runtime_ref.format_ref(), other_remote_name))
+                    break
+            if runtime_ref == None:
+                raise Exception("Could not locate runtime '%s' in any registered remotes" % ref_string)
+    except GLib.Error as e:
+        runtime_ref = None
+        raise Exception("Error finding runtimes for flatpak: %s" % e.message)
+
+    return runtime_ref
+
+def _get_remote_related_refs(fp_sys, remote_name, ref):
+    return_refs = []
+
+    try:
+        related_refs = fp_sys.list_remote_related_refs_sync(remote_name,
+                                                            ref.format_ref(),
+                                                            None)
+
+        for related_ref in related_refs:
+            if not related_ref.should_download():
+                continue
+
+            print("Found related ref '%s' in remote %s" % (related_ref.format_ref(), remote_name))
+
+            # Convert to a RemoteRef so that later functions know what remote
+            # this is from.  Related refs should never fail from the given remote,
+            # but if they're no-enumerate (as .flatpakref installs can be) then a listing
+            # will be empty, so we have ..._from_list construct a synthetic one (nofail).
+            remote_ref = _find_remote_ref_from_list(fp_sys, remote_name, related_ref, nofail=True)
+
+            return_refs.append(remote_ref)
+    except GLib.Error as e:
+        raise Exception("Could not determine remote related refs for app: %s" % e.message)
+
+    return return_refs
+
+def _get_theme_refs(fp_sys, remote_name, ref):
+    theme_refs = []
+
+    gtksettings = Gtk.Settings.get_default()
+
+    icon_theme = "org.freedesktop.Platform.Icontheme.%s" % gtksettings.props.gtk_icon_theme_name
+    gtk_theme = "org.gtk.Gtk3theme.%s" % gtksettings.props.gtk_theme_name
+
+    def sortref(ref):
+        try:
+            val = float(ref.get_branch())
+        except ValueError:
+            val = 9.9
+
+        return val
+
+    for name in (icon_theme, gtk_theme):
+        theme_ref = None
+
+        try:
+            print("Looking for theme %s in %s" % (name, remote_name))
+
+            all_refs = fp_sys.list_remote_refs_sync(remote_name, None)
+
+            matching_refs = []
+
+            for listed_ref in all_refs:
+                if listed_ref.get_name() == name:
+                    matching_refs.append(listed_ref)
+
+            if not matching_refs:
+                continue
+
+            # Sort highest version first.
+            matching_refs = sorted(matching_refs, key=sortref, reverse=True)
+
+            for matching_ref in matching_refs:
+                if matching_ref.get_arch() != ref.get_arch():
+                    continue
+
+                theme_ref = matching_ref
+                print("Found theme ref '%s' in remote %s" % (theme_ref.format_ref(), remote_name))
+                break
+
+            # if nothing is found, check other remotes
+            if theme_ref == None:
+                for other_remote in fp_sys.list_remotes():
+                    other_remote_name = other_remote.get_name()
+
+                    if other_remote_name == remote_name:
+                        continue
+
+                    print("Looking for theme %s in alternate remote %s" % (name, other_remote_name))
+
+                    all_refs = fp_sys.list_remote_refs_sync(other_remote_name, None)
+
+                    matching_refs = []
+
+                    for listed_ref in all_refs:
+                        if listed_ref.get_name() == name:
+                            matching_refs.append(listed_ref)
+
+                    if not matching_refs:
+                        continue
+
+                    # Sort highest version first.
+                    matching_refs = sorted(matching_refs, key=sortref, reverse=True)
+
+                    for matching_ref in matching_refs:
+                        if matching_ref.get_arch() != ref.get_arch():
+                            continue
+
+                        theme_ref = matching_ref
+                        print("Found theme ref '%s' in alternate remote %s" % (theme_ref.format_ref(), other_remote_name))
+                        break
+
+                    if theme_ref:
+                        break
+                if theme_ref == None:
+                    debug("Could not locate theme '%s' in any registered remotes" % name)
+        except GLib.Error as e:
+            theme_ref = None
+            debug("Error finding themes for flatpak: %s" % e.message)
+
+        if theme_ref:
+            theme_refs.append(theme_ref)
+
+    return theme_refs
+
+def _get_installed_related_refs(fp_sys, remote, ref):
+    return_refs = []
+
+    try:
+        related_refs = fp_sys.list_installed_related_refs_sync(remote,
+                                                               ref.format_ref(),
+                                                               None)
+    except GLib.Error as e:
+        raise Exception("Could not determine installed refs for app: %s" % e.message)
+
+    return related_refs
+
+def select_updates(task):
+    thread = threading.Thread(target=_select_updates_thread, args=(task,))
+    thread.start()
+
+def _select_updates_thread(task):
+    fp_sys = get_fp_sys()
+
+    try:
+        updates = fp_sys.list_installed_refs_for_update(None)
+    except GLib.Error as e:
+        task.info_ready_status = task.STATUS_BROKEN
+        task.error_message = str(e)
+        dialogs.show_flatpak_error(task.error_message)
+        if task.info_ready_callback:
+            GObject.idle_add(task.info_ready_callback, task)
+        return
+
+    for ref in updates:
+        _add_ref_to_task(fp_sys, task, ref, needs_update=True)
+
+    if len(task.to_update) > 0:
+        print("flatpaks that can be updated:")
+        for ref in task.to_update:
+            print(ref.format_ref())
+
+        task.info_ready_status = task.STATUS_OK
+        task.execute = execute_transaction
+    else:
+        print("no updated flatpaks")
+
+    if task.info_ready_callback:
+        GObject.idle_add(task.info_ready_callback, task)
+
+def select_packages(task):
+    method = None
+
+    if task.type == "install":
+        method = _pick_refs_for_installation
+    else:
+        method = _pick_refs_for_removal
+
+    print("MintInstall: Calculating changes required for Flatpak package: %s" % task.pkginfo.name)
+
+    thread = threading.Thread(target=method, args=(task,))
+    thread.start()
+
+def _pick_refs_for_installation(task):
+    fp_sys = get_fp_sys()
+
+    pkginfo = task.pkginfo
+    refid = pkginfo.refid
+
+    ref = Flatpak.Ref.parse(refid)
+    remote_name = pkginfo.remote
+
+    try:
+        remote_ref = _find_remote_ref_from_list(fp_sys, remote_name, ref, nofail=True)
+        print("Selected ref to install: '%s' in remote %s" % (remote_ref.format_ref(), remote_name))
+
+        _add_ref_to_task(fp_sys, task, remote_ref)
+        update_list = fp_sys.list_installed_refs_for_update(None)
+
+        runtime_ref = _get_runtime_ref(fp_sys, remote_name, remote_ref)
+
+        if not _is_ref_installed(fp_sys, runtime_ref):
+            _add_ref_to_task(fp_sys, task, runtime_ref)
+        else:
+            if runtime_ref in update_list:
+                _add_ref_to_task(fp_sys, task, runtime_ref, needs_update=True)
+
+        all_related_refs = _get_remote_related_refs(fp_sys, remote_ref.get_remote_name(), remote_ref)
+        all_related_refs += _get_remote_related_refs(fp_sys, runtime_ref.get_remote_name(), runtime_ref)
+        all_related_refs += _get_theme_refs(fp_sys, runtime_ref.get_remote_name(), runtime_ref)
+
+        for related_ref in all_related_refs:
+            if not _is_ref_installed(fp_sys, related_ref):
+                _add_ref_to_task(fp_sys, task, related_ref)
+            else:
+                if related_ref in update_list:
+                    _add_ref_to_task(fp_sys, task, related_ref, needs_update=True)
+
+    except Exception as e:
+        # Something went wrong, bail out
+        task.info_ready_status = task.STATUS_BROKEN
+        task.error_message = str(e)
+        dialogs.show_flatpak_error(task.error_message)
+        if task.info_ready_callback:
+            GObject.idle_add(task.info_ready_callback, task)
+        return
+
+    print("For installation:")
+    for ref in task.to_install:
+        print(ref.format_ref())
+
+    task.info_ready_status = task.STATUS_OK
+    task.execute = execute_transaction
+
+    if task.info_ready_callback:
+        GObject.idle_add(task.info_ready_callback, task)
+
+def _pick_refs_for_removal(task):
+    fp_sys = get_fp_sys()
+
+    pkginfo = task.pkginfo
+
+    try:
+        ref = fp_sys.get_installed_ref(pkginfo.kind,
+                                       pkginfo.name,
+                                       pkginfo.arch,
+                                       pkginfo.branch,
+                                       None)
+
+        remote = ref.get_origin()
+
+        _add_ref_to_task(fp_sys, task, ref)
+
+        related_refs = _get_installed_related_refs(fp_sys, remote, ref)
+
+        for related_ref in related_refs:
+            if _is_ref_installed(fp_sys, related_ref) and related_ref.should_delete():
+                _add_ref_to_task(fp_sys, task, related_ref)
+
+    except Exception as e:
+        task.info_ready_status = task.STATUS_BROKEN
+        task.error_message = str(e)
+        dialogs.show_flatpak_error(task.error_message)
+        GObject.idle_add(task.info_ready_callback, task)
+        return
+
+    print("For removal:")
+    for ref in task.to_remove:
+        print(ref.format_ref())
+
+    task.info_ready_status = task.STATUS_OK
+    task.execute = execute_transaction
+
+    if task.info_ready_callback:
+        GObject.idle_add(task.info_ready_callback, task)
+
+def list_updated_pkginfos(cache):
+    fp_sys = get_fp_sys()
+
+    updated = []
+
+    try:
+        updates = fp_sys.list_installed_refs_for_update(None)
+    except GLib.Error as e:
+        print("MintInstall: flatpak - could not get updated flatpak refs")
+        return []
+
+    for ref in updates:
+        pkg_hash = make_pkg_hash(ref)
+
+        try:
+            updated.append(cache[pkg_hash])
+        except KeyError:
+            pass
+
+    return updated
+
+def find_pkginfo(cache, string):
+    for key in cache.get_subset_of_type("f").keys():
+        candidate = cache[key]
+
+        if string == candidate.name:
+            return candidate
+
+    return None
+
+def generate_uncached_pkginfos(cache):
+    fp_sys = get_fp_sys()
+
+    try:
+        for remote in fp_sys.list_remotes():
+            remote_name = remote.get_name()
+
+            for ref in fp_sys.list_installed_refs_by_kind(Flatpak.RefKind.APP, None):
+                # All remotes will see installed refs, but the installed refs will always
+                # report their correct origin, so only add installed refs when they match the remote.
+                if ref.get_origin() == remote_name:
+                    _add_package_to_cache(cache, ref, remote.get_url(), True)
+
+    except GLib.Error as e:
+        print("MintInstall: flatpak - could not check for uncached pkginfos", e.message)
+
+def pkginfo_is_installed(pkginfo):
+    fp_sys = get_fp_sys()
+
+    try:
+        iref = fp_sys.get_installed_ref(pkginfo.kind,
+                                        pkginfo.name,
+                                        pkginfo.arch,
+                                        pkginfo.branch,
+                                        None)
+
+        if iref:
+            return True
+    except GLib.Error:
+        pass
+
+    return False
+
+def list_remotes():
+    fp_sys = get_fp_sys()
+
+    remotes = []
+
+    try:
+        for remote in fp_sys.list_remotes():
+            remotes.append(FlatpakRemoteInfo(remote))
+
+    except GLib.Error as e:
+        print("MintInstall: flatpak - could not fetch remote list", e.message)
+        remotes = []
+
+    return remotes
+
+def get_pkginfo_from_file(cache, file, callback):
+    thread = threading.Thread(target=_pkginfo_from_file_thread, args=(cache, file, callback))
+    thread.start()
+
+def _pkginfo_from_file_thread(cache, file, callback):
+    fp_sys = get_fp_sys()
+
+    path = file.get_path()
+
+    if path == None:
+        print("MintInstall: flatpak - no valid .flatpakref path provided")
+        return None
+
+    ref = None
+    pkginfo = None
+
+    with open(path) as f:
+        contents = f.read()
+
+        b = contents.encode("utf-8")
+        gb = GLib.Bytes(b)
+
+        try:
+            ref = fp_sys.install_ref_file(gb, None)
+        except GLib.Error as e:
+            if e.code == Flatpak.Error.ALREADY_INSTALLED:
+                try:
+                    kf = GLib.KeyFile()
+                    if kf.load_from_file(path, GLib.KeyFileFlags.NONE):
+                        name = kf.get_string("Flatpak Ref", "Name")
+                        branch = kf.get_string("Flatpak Ref", "Branch")
+                        url = kf.get_string("Flatpak Ref", "Url")
+                        if name and branch and url:
+                            basic_ref = Flatpak.Ref.parse("app/%s/%s/%s" % (name, Flatpak.get_default_arch(), branch))
+                            remote_name = _get_remote_name_by_url(fp_sys, url)
+
+                            ref = Flatpak.RemoteRef(remote_name=remote_name,
+                                                    kind=basic_ref.get_kind(),
+                                                    arch=basic_ref.get_arch(),
+                                                    branch=basic_ref.get_branch(),
+                                                    name=basic_ref.get_name())
+                except GLib.Error:
+                    print("MintInstall: flatpak package already installed, but an error occurred finding it")
+            elif e.code != Gio.DBusError.ACCESS_DENIED: # user cancelling auth prompt for adding a remote
+                print("MintInstall: could not read .flatpakref file: %s" % e.message)
+                dialogs.show_flatpak_error(e.message)
+
+        if ref:
+            try:
+                remote_name = ref.get_remote_name()
+                remote = fp_sys.get_remote_by_name(remote_name, None)
+
+                # Add the ref's remote if it doesn't already exist
+                _process_remote(cache, fp_sys, remote, Flatpak.get_default_arch())
+
+                # Add the ref to the cache, so we can work with it like any other in mintinstall
+                pkginfo = _add_package_to_cache(cache, ref, remote.get_url(), False)
+
+                # Fetch the appstream info for the ref
+                global _as_pools
+
+                with _as_pool_lock:
+                    if remote_name not in _as_pools.keys():
+                        _load_appstream_pool(_as_pools, remote)
+
+                # Some flatpakref files will have a pointer to a runtime .flatpakrepo file
+                # We need to process and possibly add that remote as well.
+
+                kf = GLib.KeyFile()
+                if kf.load_from_file(path, GLib.KeyFileFlags.NONE):
+                    try:
+                        url = kf.get_string("Flatpak Ref", "RuntimeRepo")
+                    except GLib.Error:
+                        url = None
+
+                    if url:
+                        # Fetch the .flatpakrepo file
+                        r = requests.get(url, stream=True)
+
+                        file = tempfile.NamedTemporaryFile(delete=False)
+
+                        with file as fd:
+                            for chunk in r.iter_content(chunk_size=128):
+                                fd.write(chunk)
+
+                        # Get the true runtime url from the repo file
+                        runtime_repo_url = _get_repofile_repo_url(file.name)
+
+                        if runtime_repo_url:
+                            existing = False
+
+                            path = Path(file.name)
+                            runtime_remote_name = Path(url).stem
+
+                            # Check if the remote is already installed
+                            for remote in fp_sys.list_remotes(None):
+                                # See comments below in _remote_from_repo_file_thread about get_noenumerate() use.
+                                if remote.get_url() == runtime_repo_url and not remote.get_noenumerate():
+                                    print("MintInstall: runtime remote '%s' already in system, skipping" % runtime_remote_name)
+                                    existing = True
+                                    break
+
+                            # if not existing:
+                            if True:
+                                print("MintInstall: Adding additional runtime remote named '%s' at '%s'" % (runtime_remote_name, runtime_repo_url))
+
+                                cmd_v = ['flatpak',
+                                         'remote-add',
+                                         '--from',
+                                         runtime_remote_name,
+                                         file.name]
+
+                                add_repo_proc = subprocess.Popen(cmd_v)
+                                retcode = add_repo_proc.wait()
+
+                                fp_sys.drop_caches(None)
+                        os.unlink(file.name)
+            except GLib.Error as e:
+                print("MintInstall: could not process .flatpakref file: %s" % e.message)
+                dialogs.show_flatpak_error(e.message)
+
+    GLib.idle_add(callback, pkginfo, priority=GLib.PRIORITY_DEFAULT)
+
+def add_remote_from_repo_file(cache, file, callback):
+    thread = threading.Thread(target=_remote_from_repo_file_thread, args=(cache, file, callback))
+    thread.start()
+
+def _remote_from_repo_file_thread(cache, file, callback):
+    try:
+        path = Path(file.get_path())
+    except TypeError:
+        print("MintInstall: flatpak - no valid .flatpakrepo path provided")
+        return
+
+    fp_sys = get_fp_sys()
+
+    # Make sure the remote isn't already setup (even under a different name)
+    # We need to exclude -origin repos - they're added for .flatpakref files
+    # if the remote isn't installed already, and get auto-removed when the app
+    # the ref file describes gets uninstalled.  -origin remotes are also marked
+    # no-enumerate, so we can filter them here by that.
+
+    existing = False
+
+    url = _get_repofile_repo_url(path)
+
+    if url:
+        for remote in fp_sys.list_remotes(None):
+            if remote.get_url() == url and not remote.get_noenumerate():
+                existing = True
+                break
+
+    if existing:
+        GObject.idle_add(callback, file, "exists")
+        return
+
+    cmd_v = ['flatpak',
+             'remote-add',
+             '--from',
+             path.stem,
+             path]
+
+    add_repo_proc = subprocess.Popen(cmd_v, stderr=subprocess.PIPE)
+    stdout, stderr = add_repo_proc.communicate()
+
+    if "Error.AccessDenied" in stderr.decode():
+        GObject.idle_add(callback, file, "cancel")
+        return
+
+    if add_repo_proc.returncode != 0 and "already exists" not in stderr.decode():
+        GObject.idle_add(callback, file, "error")
+        return
+
+    # We'll do a full cache rebuild - otherwise, after this installer session, the
+    # new apps from this remote won't show up until the next scheduled cache rebuild.
+    try:
+        fp_sys.drop_caches(None)
+    except GLib.Error:
+        pass
+
+    cache.force_new_cache_async(callback)
+
+def _get_repofile_repo_url(path):
+    kf = GLib.KeyFile()
+
+    try:
+        if kf.load_from_file(str(path), GLib.KeyFileFlags.NONE):
+            url = kf.get_string("Flatpak Repo", "Url")
+
+            return url
+    except GLib.Error as e:
+        print(e.message)
+
+    return None
+
+def execute_transaction(task):
+    if len(task.to_install + task.to_remove + task.to_update) > 1:
+        dia = ChangesConfirmDialog(None, task)
+        res = dia.run()
+        dia.hide()
+        if res != Gtk.ResponseType.OK:
+            GObject.idle_add(task.finished_cleanup_cb, task)
+            return
+
+    if task.client_progress_cb != None:
+        task.has_window = True
+    else:
+        progress_window = FlatpakProgressWindow(task)
+        progress_window.present()
+
+    thread = threading.Thread(target=_execute_transaction_thread, args=(task,))
+    thread.start()
+
+def _execute_transaction_thread(task):
+    GLib.idle_add(task.client_progress_cb, task.pkginfo, 0, True, priority=GLib.PRIORITY_DEFAULT)
+
+    fp_sys = get_fp_sys()
+
+    task.transaction = MetaTransaction(fp_sys, task)
+
+class MetaTransaction():
+    def __init__(self, fp_sys, task):
+        self.fp_sys = fp_sys
+        self.task = task
+        pkginfo = self.pkginfo = task.pkginfo
+
+        task.to_install.reverse()
+
+        self.item_count = len(task.to_install + task.to_remove + task.to_update)
+        self.current_count = 0
+
+        try:
+            for ref in task.to_install:
+                task.progress_state = task.PROGRESS_STATE_INSTALLING
+                task.current_package_name = ref.get_name()
+
+                print("installing: %s" % ref.format_ref())
+                self.fp_sys.install(ref.get_remote_name(),
+                                    ref.get_kind(),
+                                    ref.get_name(),
+                                    ref.get_arch(),
+                                    ref.get_branch(),
+                                    self.on_flatpak_progress,
+                                    None,
+                                    task.cancellable)
+
+                self.current_count += 1
+
+            for ref in task.to_remove:
+                task.progress_state = task.PROGRESS_STATE_REMOVING
+                task.current_package_name = ref.get_name()
+
+                print("removing: %s" % ref.format_ref())
+                self.fp_sys.uninstall(ref.get_kind(),
+                                      ref.get_name(),
+                                      ref.get_arch(),
+                                      ref.get_branch(),
+                                      self.on_flatpak_progress,
+                                      None,
+                                      task.cancellable)
+
+                self.current_count += 1
+
+            for ref in task.to_update:
+                task.progress_state = task.PROGRESS_STATE_UPDATING
+                task.current_package_name = ref.get_name()
+
+                print("updating: %s" % ref.format_ref())
+                self.fp_sys.update(Flatpak.UpdateFlags.NONE,
+                                   ref.get_remote_name(),
+                                   ref.get_kind(),
+                                   ref.get_name(),
+                                   ref.get_arch(),
+                                   ref.get_branch(),
+                                   self.on_flatpak_progress,
+                                   None,
+                                   task.cancellable)
+
+                self.current_count += 1
+        except GLib.Error as e:
+            if e.code != Gio.IOErrorEnum.CANCELLED:
+                task.progress_state = task.PROGRESS_STATE_FAILED
+                task.current_package_name = None
+                self.on_flatpak_error(e.message)
+                return
+
+        task.progress_state = task.PROGRESS_STATE_FINISHED
+        task.current_package_name = None
+        self.on_flatpak_finished()
+
+    def on_flatpak_progress(self, status, progress, estimating, data=None):
+        # Simple for now, each package gets an equal slice, and package progress is a percentage of that slice
+
+        package_chunk_size = 1.0 / self.item_count
+        partial_chunk = (progress / 100.0) * package_chunk_size
+
+        actual_progress = math.floor(((self.current_count * package_chunk_size) + partial_chunk) * 100.0)
+
+        GLib.idle_add(self.task.client_progress_cb,
+                      self.task.pkginfo,
+                      actual_progress,
+                      estimating,
+                      priority=GLib.PRIORITY_DEFAULT)
+
+    def on_flatpak_error(self, error_details):
+        self.task.error_message = error_details
+
+        # Show an error popup only if we're in mintinstall, otherwise a flatpak
+        # progress window will show the error details
+        if self.task.has_window:
+            dialogs.show_flatpak_error(error_details)
+
+        GLib.idle_add(self.task.error_cleanup_cb, self.task)
+
+    def on_flatpak_finished(self):
+        self.fp_sys.drop_caches(None)
+
+        GLib.idle_add(self.task.finished_cleanup_cb, self.task)
+
+

--- a/usr/lib/python3/dist-packages/mintcommon/installer/cache.py
+++ b/usr/lib/python3/dist-packages/mintcommon/installer/cache.py
@@ -1,0 +1,290 @@
+import time
+import os
+from pathlib import Path
+import pickle
+import threading
+
+import gi
+gi.require_version('AppStream', '1.0')
+from gi.repository import GLib, GObject
+
+from . import _apt
+from . import _flatpak
+from .pkgInfo import PkgInfo
+from .misc import print_timing
+
+SYS_CACHE_PATH = "/var/cache/mintinstall/pkginfo.cache"
+USER_CACHE_PATH = os.path.join(GLib.get_user_cache_dir(), "mintinstall", "pkginfo.cache")
+
+MAX_AGE = 7 * (60 * 60 * 24) # days
+
+class CacheLoadingException(Exception):
+    '''Thrown when there was an issue loading the pickled package set'''
+
+class PickleObject(object):
+    def __init__(self, pkginfo_cache, section_lists, flatpak_remote_infos):
+        super(PickleObject, self).__init__()
+
+        self.pkginfo_cache = pkginfo_cache
+        self.section_lists = section_lists
+        self.flatpak_remote_infos = flatpak_remote_infos
+
+class PkgCache(object):
+    STATUS_EMPTY = 0
+    STATUS_OK = 1
+
+    @print_timing
+    def __init__(self, have_flatpak=False):
+        super(PkgCache, self).__init__()
+
+        self.status = self.STATUS_EMPTY
+        self.have_flatpak = have_flatpak
+
+        self._items = {}
+        self._item_lock = threading.Lock()
+
+        try:
+            cache, sections, flatpak_remote_infos = self._load_cache()
+        except CacheLoadingException:
+            cache = {}
+            sections = {}
+            flatpak_remote_infos = {}
+
+        if len(cache) > 0:
+            self.status = self.STATUS_OK
+        else:
+            self.status = self.STATUS_EMPTY
+
+        self._items = cache
+        self.sections = sections
+        self.flatpak_remote_infos = flatpak_remote_infos
+
+    def keys(self):
+        with self._item_lock:
+            return self._items.keys()
+
+    def values(self):
+        with self._item_lock:
+            return self._items.values()
+
+    def __getitem__(self, key):
+        with self._item_lock:
+            return self._items[key]
+
+    def __setitem__(self, key, value):
+        with self._item_lock:
+            self._items[key] = value
+
+    def __delitem__(self, key):
+        with self._item_lock:
+            del self._items[key]
+
+    def __contains__(self, pkg_hash):
+        with self._item_lock:
+            return pkg_hash in self._items
+
+    def __len__(self):
+        with self._item_lock:
+            return len(self._items)
+
+    def __iter__(self):
+        with self._item_lock:
+            for pkg_hash in self._items:
+                yield self[pkg_hash]
+            return
+
+    def _generate_cache(self):
+        cache = {}
+        sections = {}
+        flatpak_remote_infos = {}
+
+        if self.have_flatpak:
+            cache, flatpak_remote_infos = _flatpak.process_full_flatpak_installation(cache)
+
+        cache, sections = _apt.process_full_apt_cache(cache)
+
+        return cache, sections, flatpak_remote_infos
+
+    def _get_best_load_path(self):
+        try:
+            sys_mtime = os.path.getmtime(SYS_CACHE_PATH)
+
+            if ((time.time() - MAX_AGE) > sys_mtime) or not os.access(SYS_CACHE_PATH, os.R_OK):
+                print("MintInstall: System pkgcache too old or not accessible, skipping")
+                sys_mtime = 0
+        except OSError:
+            sys_mtime = 0
+
+        try:
+            user_mtime = os.path.getmtime(USER_CACHE_PATH)
+
+            if (time.time() - MAX_AGE) > user_mtime:
+                print("MintInstall: User pkgcache too old, skipping")
+                user_mtime = 0
+        except OSError:
+            user_mtime = 0
+
+        # If neither exist, return None, and a new cache will be generated
+        if sys_mtime == 0 and user_mtime == 0:
+            return None
+
+        most_recent = None
+
+        # Select the most recent
+        if sys_mtime > user_mtime:
+            most_recent = SYS_CACHE_PATH
+            print("MintInstall: System pkgcache is most recent, using it.")
+        else:
+            most_recent = USER_CACHE_PATH
+            print("MintInstall: User pkgcache is most recent, using it.")
+
+        return Path(most_recent)
+
+    @print_timing
+    def _load_cache(self):
+        """
+        The cache pickle file can be in either a system or user location,
+        depending on how the cache was generated.  If it exists in both places, take the
+        most recent one.  If it's more than MAX_AGE, generate a new one anyhow.
+        """
+
+        cache = None
+        sections = None
+        flatpak_remote_infos = None
+
+        path = self._get_best_load_path()
+
+        if path is None:
+            raise CacheLoadingException
+
+        try:
+            with path.open(mode='rb') as f:
+                pickle_obj = pickle.load(f)
+                cache = pickle_obj.pkginfo_cache
+                sections = pickle_obj.section_lists
+                flatpak_remote_infos = pickle_obj.flatpak_remote_infos
+        except Exception as e:
+            print("MintInstall: Error loading pkginfo cache:", e)
+            cache = None
+
+        if cache == None:
+            raise CacheLoadingException
+
+        return cache, sections, flatpak_remote_infos
+
+    def _get_best_save_path(self):
+        best_path = None
+
+        # Prefer the system location, as all users can access it
+        try:
+            path = Path(SYS_CACHE_PATH)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.touch(exist_ok=True)
+        except PermissionError:
+            try:
+                path = Path(USER_CACHE_PATH)
+                path.parent.mkdir(parents=True, exist_ok=True)
+            except Exception:
+                path = None
+        finally:
+            best_path = path
+
+        return best_path
+
+    def _save_cache(self, to_be_pickled):
+        path = self._get_best_save_path()
+
+        # Depickling later may fail if we _load_cache from a different context or module.
+        # This explicitly stores the module name PkgInfo is defined in, within the pickle
+        # file.
+        PkgInfo.__module__ = "installer.pkgInfo"
+
+        try:
+            with path.open(mode='wb') as f:
+                pickle.dump(to_be_pickled, f)
+        except Exception as e:
+            print("MintInstall: Could not save cache:", str(e))
+
+    def _new_cache_common(self):
+        print("MintInstall: Generating new pkgcache")
+        cache, sections, flatpak_remote_infos = self._generate_cache()
+
+        if len(cache) > 0:
+            self._save_cache(PickleObject(cache, sections, flatpak_remote_infos))
+
+        with self._item_lock:
+            self._items = cache
+            self.sections = sections
+            self.flatpak_remote_infos = flatpak_remote_infos
+
+        if len(cache) == 0:
+            self.status = self.STATUS_EMPTY
+        else:
+            self.status = self.STATUS_OK
+
+    def _generate_cache_thread(self, callback=None):
+        self._new_cache_common()
+
+        if callback != None:
+            GObject.idle_add(callback)
+
+    def get_subset_of_type(self, pkg_type):
+        with self._item_lock:
+            return {k: v for k, v in self._items.items() if k.startswith(pkg_type)}
+
+    def force_new_cache_async(self, idle_callback=None):
+        thread = threading.Thread(target=self._generate_cache_thread,
+                                  kwargs={"callback" : idle_callback})
+        thread.start()
+
+    def force_new_cache(self):
+        self._new_cache_common()
+
+    def find_pkginfo(self, string, pkg_type=None):
+        if pkg_type in (None, "a"):
+            pkginfo = _apt.find_pkginfo(self, string)
+
+            if pkginfo != None:
+                return pkginfo
+
+        if self.have_flatpak:
+            if pkg_type in (None, "f"):
+                pkginfo = _flatpak.find_pkginfo(self, string)
+
+                if pkginfo != None:
+                    return pkginfo
+
+        return None
+
+    def _get_manually_installed_debs(self):
+        """
+        Generate list of manually installed Debian package.
+        Requires a package list provided by the installer.
+            Currently knows only Ubiquity's /var/log/installer/initial-status.gz
+        """
+        installer_log = "/var/log/installer/initial-status.gz"
+        if not os.path.isfile(installer_log):
+            return None
+        import gzip
+        installer_log = gzip.open(installer_log, "r").read().decode('utf-8').splitlines()
+        initial_status = [x[9:] for x in installer_log if x.startswith("Package: ")]
+        if not initial_status:
+            return None
+        from . import _apt
+        pkgcache = [x[4:] for x in self.get_subset_of_type("a")]
+        current_status = [f"apt:{pkg}" for pkg in _apt.get_apt_cache() if
+            (pkg.installed and
+            not pkg.is_auto_installed and
+            pkg.shortname not in initial_status and
+            pkg.shortname in pkgcache)]
+        return current_status
+
+    def get_manually_installed_packages(self):
+        """ Get list of all manually installed packages (apt and flatpak) """
+        installed_packages = None
+        installed_packages_apt = self._get_manually_installed_debs()
+        if installed_packages_apt:
+            installed_packages = installed_packages_apt
+            installed_packages += [x for x in self.get_subset_of_type("f")]
+        return installed_packages
+

--- a/usr/lib/python3/dist-packages/mintcommon/installer/dialogs.py
+++ b/usr/lib/python3/dist-packages/mintcommon/installer/dialogs.py
@@ -1,0 +1,325 @@
+import gi
+gi.require_version('XApp', '1.0')
+from gi.repository import GLib, Gtk, GObject, Gdk, XApp
+
+import gettext
+APP = 'mintinstall'
+LOCALE_DIR = "/usr/share/linuxmint/locale"
+gettext.bindtextdomain(APP, LOCALE_DIR)
+gettext.textdomain(APP)
+_ = gettext.gettext
+
+from aptdaemon.gtk3widgets import AptConfirmDialog
+
+######################### Subclass Apt's dialog to keep consistency
+
+class ChangesConfirmDialog(AptConfirmDialog):
+
+    """Dialog to confirm the changes that would be required by a
+    transaction.
+    """
+
+    def __init__(self, transaction, task):
+        super(ChangesConfirmDialog, self).__init__(transaction, cache=None, parent=task.parent_window)
+
+        self.task = task
+
+    def _show_changes(self):
+        """Show a message and the dependencies in the dialog."""
+        self.treestore.clear()
+
+        # Run parent method for apt
+        if self.task.pkginfo.pkg_hash.startswith("a"):
+            super(ChangesConfirmDialog, self)._show_changes()
+        else:
+            # flatpak
+            self.set_title(_("Flatpaks"))
+
+            if len(self.task.to_install) > 0:
+                piter = self.treestore.append(None, ["<b>%s</b>" % _("Install")])
+
+                for ref in self.task.to_install:
+                    if self.task.pkginfo.refid == ref.format_ref():
+                        continue
+
+                    self.treestore.append(piter, [ref.get_name()])
+
+            if len(self.task.to_remove) > 0:
+                piter = self.treestore.append(None, ["<b>%s</b>" % _("Remove")])
+
+                for ref in self.task.to_remove:
+                    if self.task.pkginfo.refid == ref.format_ref():
+                        continue
+
+                    self.treestore.append(piter, [ref.get_name()])
+
+            if len(self.task.to_update) > 0:
+                piter = self.treestore.append(None, ["<b>%s</b>" % _("Upgrade")])
+
+                for ref in self.task.to_update:
+                    if self.task.pkginfo.refid == ref.format_ref():
+                        continue
+
+                    self.treestore.append(piter, [ref.get_name()])
+
+            msg = _("Please take a look at the list of changes below.")
+
+            if len(self.treestore) == 1:
+                filtered_store = self.treestore.filter_new(
+                    Gtk.TreePath.new_first())
+                self.treeview.expand_all()
+                self.treeview.set_model(filtered_store)
+                self.treeview.set_show_expanders(False)
+
+                if len(self.task.to_install) > 0:
+                    title = _("Additional software has to be installed")
+                elif len(self.task.to_remove) > 0:
+                    title = _("Additional software has to be removed")
+                elif len(self.task.to_update) > 0:
+                    title = _("Additional software has to be upgraded")
+
+                if len(filtered_store) < 6:
+                    self.set_resizable(False)
+                    self.scrolled.set_policy(Gtk.PolicyType.AUTOMATIC,
+                                             Gtk.PolicyType.NEVER)
+                else:
+                    self.treeview.set_size_request(350, 200)
+            else:
+                title = _("Additional changes are required")
+                self.treeview.set_size_request(350, 200)
+                self.treeview.collapse_all()
+
+            if self.task.download_size > 0:
+                msg += "\n"
+                msg += (_("%s will be downloaded in total.") %
+                        GLib.format_size(self.task.download_size))
+            if self.task.freed_size > 0:
+                msg += "\n"
+                msg += (_("%s of disk space will be freed.") %
+                        GLib.format_size(self.task.freed_size))
+            elif self.task.install_size > 0:
+                msg += "\n"
+                msg += (_("%s more disk space will be used.") %
+                        GLib.format_size(self.task.install_size))
+            self.label.set_markup("<b><big>%s</big></b>\n\n%s" % (title, msg))
+
+    def render_package_desc(self, column, cell, model, iter, data):
+        value = model.get_value(iter, 0)
+
+        cell.set_property("markup", value)
+
+
+class FlatpakProgressWindow(Gtk.Dialog):
+    """
+    Progress dialog for standalone flatpak installs, removals, updates.
+    Intended to be used when not working as part of a parent app (like mintinstall)
+    """
+
+    def __init__(self, task, parent=None):
+        Gtk.Dialog.__init__(self, parent=parent)
+
+        self.task = task
+        self.finished = False
+
+        # Progress goes directly to this window
+        task.client_progress_cb = self.window_client_progress_cb
+
+        # finished callbacks route thru the installer
+        # but we want to see them in this window also.
+        self.final_finished_cb = task.client_finished_cb
+        task.client_finished_cb = self.window_client_finished_cb
+
+        self.pulse_timer = 0
+        self.active_task_state = task.progress_state
+
+        self.real_progress_text = None
+        self.num_dots = 0
+
+        # Setup the dialog
+        self.set_border_width(6)
+        self.set_resizable(False)
+        self.get_content_area().set_spacing(6)
+        # Setup the cancel button
+        self.button = Gtk.Button.new_from_stock(Gtk.STOCK_CANCEL)
+        self.button.set_use_stock(True)
+        self.get_action_area().pack_start(self.button, False, False, 0)
+        self.button.connect("clicked", self.on_button_clicked)
+        self.button.show()
+
+        # labels and progressbar
+        hbox = Gtk.HBox()
+        hbox.set_spacing(12)
+        hbox.set_border_width(6)
+        vbox = Gtk.VBox()
+        vbox.set_spacing(12)
+
+        self.phase_label = Gtk.Label()
+        vbox.pack_start(self.phase_label, False, False, 0)
+        self.phase_label.set_halign(Gtk.Align.START)
+
+        vbox_progress = Gtk.VBox()
+        vbox_progress.set_spacing(6)
+        self.progress = Gtk.ProgressBar()
+        vbox_progress.pack_start(self.progress, False, True, 0)
+
+        self.progress_label = Gtk.Label()
+        vbox_progress.pack_start(self.progress_label, False, False, 0)
+        self.progress_label.set_halign(Gtk.Align.START)
+        self.progress_label.set_line_wrap(True)
+        self.progress_label.set_max_width_chars(60)
+
+        vbox.pack_start(vbox_progress, False, True, 0)
+        hbox.pack_start(vbox, True, True, 0)
+
+        self.get_content_area().pack_start(hbox, True, True, 0)
+
+        self.set_title(_("Flatpak Progress"))
+        XApp.set_window_icon_name(self, "system-software-installer")
+
+        hbox.show_all()
+        self.realize()
+
+        self.progress.set_size_request(350, -1)
+        functions = Gdk.WMFunction.MOVE | Gdk.WMFunction.RESIZE
+        try:
+            self.get_window().set_functions(functions)
+        except TypeError:
+            # workaround for older and broken GTK typelibs
+            self.get_window().set_functions(Gdk.WMFunction(functions))
+
+        self.update_labels()
+
+        # catch ESC and behave as if cancel was clicked
+        self.connect("delete-event", self._on_dialog_delete_event)
+
+    def set_progress_text(self, text):
+        if text != self.real_progress_text:
+            self.real_progress_text = text
+            self.progress_label.set_text(text)
+        else:
+            self.tick()
+
+    def tick(self):
+        if self.num_dots < 5:
+            self.num_dots += 1
+        else:
+            self.num_dots = 0
+
+        new_string = self.real_progress_text
+
+        i = 0
+
+        while i < self.num_dots:
+            new_string += "."
+            i += 1
+
+        self.progress_label.set_text(new_string)
+
+    def update_labels(self):
+        phase_label = ""
+
+        if self.task.cancellable.is_cancelled():
+            phase_label = _("Cancelled")
+            self.set_progress_text(_("The operation was cancelled before it could complete."))
+        elif self.task.progress_state == self.task.PROGRESS_STATE_INIT:
+            phase_label = _("Initializing")
+            self.set_progress_text("")
+        elif self.task.progress_state == self.task.PROGRESS_STATE_INSTALLING:
+            phase_label = _("Installing flatpaks")
+            self.set_progress_text(_("Installing: %s") % self.task.current_package_name)
+        elif self.task.progress_state == self.task.PROGRESS_STATE_REMOVING:
+            phase_label = _("Removing flatpaks")
+            self.set_progress_text(_("Removing: %s") % self.task.current_package_name)
+        elif self.task.progress_state == self.task.PROGRESS_STATE_UPDATING:
+            phase_label = _("Updating flatpaks")
+            self.set_progress_text(_("Updating: %s") % self.task.current_package_name)
+        elif self.task.progress_state == self.task.PROGRESS_STATE_FINISHED:
+            phase_label = _("Finished")
+            self.set_progress_text(_("Operation completed successfully"))
+        elif self.task.progress_state == self.task.PROGRESS_STATE_FAILED:
+            phase_label = _("Failed")
+            self.set_progress_text(_("An error occurred:\n\n%s") % self.task.error_message)
+
+        self.phase_label.set_markup("<big><b>%s</b></big>" % phase_label)
+        self.set_title(phase_label)
+
+    def start_progress_pulse(self):
+        if self.pulse_timer > 0:
+            return
+
+        self.progress.pulse()
+        self.pulse_timer = GObject.timeout_add(1050, self.progress_pulse_tick)
+
+    def progress_pulse_tick(self):
+        self.progress.pulse()
+
+        return GLib.SOURCE_CONTINUE
+
+    def stop_progress_pulse(self):
+        if self.pulse_timer > 0:
+            GObject.source_remove(self.pulse_timer)
+            self.pulse_timer = 0
+
+    def _on_dialog_delete_event(self, dialog, event):
+        self.button.clicked()
+        return True
+
+    def window_client_progress_cb(self, pkginfo, progress, estimating):
+        if estimating:
+            self.start_progress_pulse()
+        else:
+            self.stop_progress_pulse()
+
+            self.progress.set_fraction(progress / 100.0)
+            XApp.set_window_progress(self, progress)
+            self.tick()
+
+        self.update_labels()
+
+    def window_client_finished_cb(self, pkginfo, error_message):
+        self.finished = True
+
+        XApp.set_window_progress(self, 0)
+        self.stop_progress_pulse()
+
+        self.progress.set_fraction(1.0)
+
+        self.update_labels()
+
+        if error_message:
+            self.set_urgency_hint(True)
+            self.button.set_label(Gtk.STOCK_CLOSE)
+        else:
+            self.destroy()
+            self.final_finished_cb(self.task.pkginfo, error_message)
+
+    def on_button_clicked(self, button):
+        if not self.finished:
+            self.task.cancellable.cancel()
+        else:
+            self.destroy()
+            self.final_finished_cb(self.task.pkginfo, self.task.error_message)
+
+def show_flatpak_error(message):
+    GObject.idle_add(_show_flatpak_error_mainloop, message, priority=GLib.PRIORITY_DEFAULT)
+
+def _show_flatpak_error_mainloop(message):
+
+    dialog = Gtk.MessageDialog(None,
+                               Gtk.DialogFlags.DESTROY_WITH_PARENT,
+                               Gtk.MessageType.ERROR,
+                               Gtk.ButtonsType.OK,
+                               "")
+
+    text = _("An error occurred")
+    dialog.set_markup("<big><b>%s</b></big>" % text)
+    message_label = Gtk.Label(message)
+    dialog.get_message_area().pack_start(message_label, False, False, 6)
+    message_label.set_line_wrap(True)
+    message_label.set_max_width_chars(60)
+    message_label.show()
+
+    dialog.run()
+    dialog.hide()
+
+    return False

--- a/usr/lib/python3/dist-packages/mintcommon/installer/installer.py
+++ b/usr/lib/python3/dist-packages/mintcommon/installer/installer.py
@@ -1,0 +1,569 @@
+#!/usr/bin/python3
+import threading
+import signal
+import time
+
+import gi
+gi.require_version('AppStream', '1.0')
+from gi.repository import GLib, GObject, Gio
+
+from . import cache, _flatpak, _apt
+from .misc import print_timing
+
+PKG_TYPE_NONE = None
+PKG_TYPE_APT = "a"
+PKG_TYPE_FLATPAK = "f"
+
+# the action that initiated the task
+INSTALL_TASK = "install"
+UNINSTALL_TASK = "remove"
+UPDATE_TASK = "update"
+
+class InstallerTask:
+    # Set after a package selection, reflects whether task can proceed or not
+    STATUS_NONE = "none"
+    STATUS_OK = "ok"
+    STATUS_BROKEN = "broken"
+    STATUS_FORBIDDEN = "forbidden"
+
+    # Used by standalone progress window to update labels appropriately
+    PROGRESS_STATE_INIT = "init"
+    PROGRESS_STATE_INSTALLING = "installing"
+    PROGRESS_STATE_UPDATING = "updating"
+    PROGRESS_STATE_REMOVING = "removing"
+    PROGRESS_STATE_FINISHED = "finished"
+    PROGRESS_STATE_FAILED = "failed"
+
+    def __init__(self, pkginfo, installer, info_ready_callback):
+        self.type = INSTALL_TASK
+
+        self.parent_window = None
+
+        # pkginfo will be None for an update task
+        self.pkginfo = pkginfo
+
+        self.name = None
+
+        # Set by .select_pkginfo(), the re-entry point after a task is fully
+        # calculated, and the UI should be updated with detailed info about
+        # the pending operation (disk use, etc..)
+        self.info_ready_callback = info_ready_callback
+        # To be checked by the info_ready_callback, to allow the UI to reflect
+        # the ability to proceed with a task, or report that something is not right.
+        self.info_ready_status = self.STATUS_NONE
+
+        # Set by the backend, the function to call to actually perform the task (will
+        # be none on STATUS_BROKEN or _FORBIDDEN)
+        self.execute = None
+
+        # Passed to _flatpak operations to respond to the Cancel button in the
+        # standalone progress window. eventually it may be used elsewhere.
+        self.cancellable = Gio.Cancellable()
+
+        # Callbacks that will be used at various points during a task being operated on.
+        # The .client_* callbacks are arguments of Installer.execute_task().  The
+        # client_finished_cb is required.  If the progress callback is missing, a standalone
+        # progress window will be provided.
+        self.client_progress_cb = None
+        self.client_finished_cb = None
+
+        # These are internally used - called as the 'real' error and finished callback,
+        # to do some cleanup like removing the task and reloading the apt cache before
+        # finally calling task.client_finished_cb
+        self.error_cleanup_cb = None
+        self.finished_cleanup_cb = None
+
+        self.has_window = False
+        # Updated throughout a flatpak operation - for now it's used for updating the
+        # standalone flatpak progress window
+        self.progress_state = self.PROGRESS_STATE_INIT
+        # Same - allows the flatpak window to update the current package being installed/removed
+        self.current_package_name = None
+        # The error message displayed in a popup if a flatpak operation fails.
+        self.error_message = None
+
+        # apt only, stores the AptTransaction
+        self.transaction = None
+
+        # The command that can be used to launch the current target package, if it's installed
+        self.exec_string = None
+
+        # List of additional packages to install, remove or update, based on the selected
+        # pkginfo. Always lists of strings, but depending on the backend, they will consist
+        # of package names (apt) or stringified flatpak refs (the result of ref.format_ref())
+        self.to_install = []
+        self.to_remove = []
+        self.to_update = []
+
+        # Size info for display, calculated by the backend during .select_pkginfo()
+        self.download_size = 0
+        self.install_size = 0
+        self.freed_size = 0
+
+        # Static info filled in for display
+        if pkginfo:
+            self.name = pkginfo.name
+
+            if pkginfo.pkg_hash.startswith("a"):
+                self.arch = ""
+                self.branch = ""
+                self.remote = ""
+            else:
+                self.arch = pkginfo.arch
+                self.remote = pkginfo.remote
+                self.branch = pkginfo.branch
+
+            self.version = installer.get_version(pkginfo)
+
+class Installer:
+    def __init__(self):
+        self.tasks = {}
+
+        self.remotes_changed = False
+        self.inited = False
+
+        self.have_flatpak = False
+        self._determine_flatpak_status()
+
+        self.cache = {}
+        self._init_cb = None
+
+        self.startup_timer = time.time()
+
+    def _determine_flatpak_status(self):
+        try:
+            gi.require_version('Flatpak', '1.0')
+            from gi.repository import Flatpak
+
+            self.have_flatpak = True
+
+            return
+        except:
+            print("No flatpak support, install flatpak and gir1.2-flatpak-1.0 and restart mintinstall to enable it.")
+
+        self.have_flatpak = False
+
+    def init_sync(self):
+        """
+        Loads the cache asynchronously.  Returns True if all went ok, and returns False if there
+        is no cache (or it's too old.)  You should then call init() with a callback so the cache
+        can be regenerated.
+        """
+        self.settings = Gio.Settings(schema_id="com.linuxmint.install")
+
+        if self._fp_remotes_have_changed():
+            self.remotes_changed = True
+            return False
+
+        self.backend_table = {}
+
+        self.cache = cache.PkgCache(self.have_flatpak)
+
+        if self.cache.status == self.cache.STATUS_OK:
+            self.inited = True
+
+            GObject.idle_add(self.initialize_appstream)
+            self.generate_uncached_pkginfos(self.cache)
+
+            return True
+
+        return False
+
+    def init(self, ready_callback=None):
+        """
+        Loads the cache asynchronously.  If there is no cache (or it's too old,) it causes
+        one to be generated and saved.  The ready_callback is called on idle once this is finished.
+        """
+        self.backend_table = {}
+
+        self.cache = cache.PkgCache(self.have_flatpak)
+
+        self._init_cb = ready_callback
+
+        if self.cache.status == self.cache.STATUS_OK and not self.remotes_changed:
+            self.inited = True
+
+            GObject.idle_add(self._idle_cache_load_done)
+        else:
+            if self.remotes_changed:
+                print("MintInstall: Flatpak remotes have changed, forcing a new cache.")
+
+            self.cache.force_new_cache_async(self._idle_cache_load_done)
+
+        return self
+
+    def force_new_cache(self, ready_callback=None):
+        """
+        Forces the cache to regenerate, calling read_callback when complete
+        """
+        self.cache.force_new_cache_async(ready_callback)
+
+    def _idle_cache_load_done(self):
+        self.inited = True
+
+        if self.remotes_changed:
+            self._store_remotes()
+            self.remotes_changed = False
+
+        GObject.idle_add(self.initialize_appstream)
+
+        self.generate_uncached_pkginfos(self.cache)
+
+        print('Full installer startup took %0.3f ms' % ((time.time() - self.startup_timer) * 1000.0))
+
+        if self._init_cb:
+            self._init_cb()
+
+    @print_timing
+    def _fp_remotes_have_changed(self):
+        """
+        We check here for changed remotes.  We care if names, urls, and disabled status changed.
+        The 'noenumerate' property won't change, and is usually marked on standalone (-source) ref
+        installs.  We don't want to generate a new cache for those - their app can be accessed via
+        installed apps, plus if you uninstall the app, the remote gets auto-removed.
+        """
+        changed = False
+        real_remote_count = 0;
+
+        saved_remotes = self.settings.get_strv("flatpak-remotes")
+        fp_remotes = self.list_flatpak_remotes()
+
+        for remote_info in fp_remotes:
+            if remote_info.noenumerate:
+                continue
+
+            real_remote_count += 1
+
+            item = "%s::%s::%s" % (remote_info.name, remote_info.url, str(remote_info.disabled))
+
+            if item not in saved_remotes:
+                changed = True
+                break
+
+        if not changed:
+            if len(saved_remotes) != real_remote_count:
+                changed = True
+
+        return changed
+
+    @print_timing
+    def _store_remotes(self):
+        new_remotes = []
+
+        fp_remotes = self.list_flatpak_remotes()
+
+        for remote_info in fp_remotes:
+            if remote_info.noenumerate:
+                continue
+
+            item = "%s::%s::%s" % (remote_info.name, remote_info.url, str(remote_info.disabled))
+
+            new_remotes.append(item)
+
+        self.settings.set_strv("flatpak-remotes", new_remotes)
+
+    def select_pkginfo(self, pkginfo, ready_callback):
+        """
+        Initiates calculations for installing or removing a particular package
+        (depending upon whether or not the selected package is installed.  Creates
+        an InstallerTask instance and populates it with info relevant for display
+        and for execution later.  When this is completed, ready_callback is called,
+        with the newly-created task as its argument.  Note:  At that point, this is
+        the *only* reference to the task object.  It can be safely discarded.  If
+        the task is to be run, Installer.execute_task() is called, passing this task
+        object, along with callback functions.  The task object is then added to a
+        queue (and is tracked in self.tasks from there on out.)
+        """
+        if pkginfo.pkg_hash in self.tasks.keys():
+            task = self.tasks[pkginfo.pkg_hash]
+
+            GObject.idle_add(task.info_ready_callback, task)
+            return
+
+        task = InstallerTask(pkginfo, self, ready_callback)
+
+        if self.pkginfo_is_installed(pkginfo):
+            # It's not installed, so assume we're installing
+            task.type = UNINSTALL_TASK
+        else:
+            task.type = INSTALL_TASK
+
+        if pkginfo.pkg_hash.startswith("a"):
+            _apt.select_packages(task)
+        else:
+            _flatpak.select_packages(task)
+
+    def prepare_flatpak_update(self, ready_callback):
+        """
+        Creates an InstallerTask populated with all flatpak packages that can be
+        updated.  Note, unlike select_pkginfo, there is no 'primary' package here.
+        Only disk utilization and download info, along with the list of ref strings
+        (in task.to_update) will be populated.
+        """
+        task = InstallerTask(None, self, ready_callback)
+
+        task.type = UPDATE_TASK
+
+        _flatpak.select_updates(task)
+
+    def list_updated_flatpak_pkginfos(self):
+        """
+        Returns a list of flatpak pkginfos that can be updated.  Unlike
+        prepare_flatpak_update, this is for the convenience of displaying information
+        to the user.
+        """
+        return _flatpak.list_updated_pkginfos(self.cache)
+
+    def find_pkginfo(self, name, pkg_type=PKG_TYPE_NONE):
+        """
+        Attempts to find and return a PkgInfo object, given a package name.  If
+        pkg_type is None, looks in first apt, then flatpaks.
+        """
+        return self.cache.find_pkginfo(name, pkg_type)
+
+    def get_pkginfo_from_ref_file(self, file, ready_callback):
+        """
+        Accepts a GFile to a .flatpakref on a local path.  If the flatpak's remote
+        has not been previously added to the system installation, this also adds
+        it and downloads Appstream info as well, before calling ready_callback with
+        the created (or existing) PkgInfo as an argument.
+        """
+        if self.have_flatpak:
+            _flatpak.get_pkginfo_from_file(self.cache, file, ready_callback)
+
+    def add_remote_from_repo_file(self, file, ready_callback):
+        """
+        Accepts a GFile to a .flatpakrepo on a local path.  Adds the remote if it
+        doesn't exist already, fetches any appstream data, and then calls
+        ready_callback
+        """
+
+        if self.have_flatpak:
+            _flatpak.add_remote_from_repo_file(self.cache, file, ready_callback)
+        else:
+            ready_callback(None, "no-flatpak-support")
+
+    def list_flatpak_remotes(self):
+        """
+        Returns a list of FlatpakRemoteInfos.  The remote_name can be used to match
+        with PkgInfo.remote and the title is for display.
+        """
+        if self.have_flatpak:
+            return _flatpak.list_remotes()
+        else:
+            return []
+
+    def pkginfo_is_installed(self, pkginfo):
+        """
+        Returns whether or not a given package is currently installed.  This uses
+        the AptCache or the FlatpakInstallation to check.
+        """
+        if self.inited:
+            if pkginfo.pkg_hash.startswith("a"):
+                return _apt.pkginfo_is_installed(pkginfo)
+            elif self.have_flatpak and pkginfo.pkg_hash.startswith("f"):
+                return _flatpak.pkginfo_is_installed(pkginfo)
+
+        return False
+
+    @print_timing
+    def generate_uncached_pkginfos(self, cache):
+        """
+        Flatpaks installed from .flatpakref files may not actually be in the saved
+        pkginfo cache, specifically, if they're added from no-enumerate-marked remotes.
+        This gets run at startup to collect and generate their info.
+        """
+        if self.have_flatpak:
+            _flatpak.generate_uncached_pkginfos(cache)
+
+    @print_timing
+    def initialize_appstream(self):
+        """
+        Loads and caches the AppStream pools so they can be used to provide
+        display info for packages.
+        """
+        if self.have_flatpak:
+            _flatpak.initialize_appstream()
+        # Is there any reason to use apt's appstream?
+
+    def _get_backend_component(self, pkginfo):
+        try:
+            backend_component = self.backend_table[pkginfo]
+
+            return backend_component
+        except KeyError:
+            if pkginfo.pkg_hash.startswith("a"):
+                backend_component = _apt.search_for_pkginfo_apt_pkg(pkginfo)
+            else:
+                if self.have_flatpak:
+                    backend_component = _flatpak.search_for_pkginfo_as_component(pkginfo)
+
+            self.backend_table[pkginfo] = backend_component
+
+            # It's possible at some point we'll refresh appstream at runtime, if so we'll
+            # want to clear cached data so it can be re-fetched anew.  For now there's
+            # no need. The only possible case is on-demand adding of a remote (from
+            # launching a .flatpakref file), and in this case, we won't have had anything
+            # cached for it to clear anyhow.
+
+            # pkginfo.clear_cached_info()
+
+            return backend_component
+
+    def get_display_name(self, pkginfo):
+        """
+        Returns the name of the package formatted for displaying
+        """
+        comp = self._get_backend_component(pkginfo)
+
+        return pkginfo.get_display_name(comp)
+
+    def get_summary(self, pkginfo, for_search=False):
+        """
+        Returns the summary of the package.  If for_search is True,
+        this is the raw, unformatted string in the case of apt.
+        """
+        if for_search and pkginfo.pkg_hash.startswith("a"):
+            try:
+                return _apt._apt_cache[pkginfo.name].candidate.summary
+            except Exception:
+                pass
+
+        comp = self._get_backend_component(pkginfo)
+
+        return pkginfo.get_summary(comp)
+
+    def get_description(self, pkginfo, for_search=False):
+        """
+        Returns the description of the package.  If for_search is True,
+        this is the raw, unformatted string in the case of apt.
+        """
+        if for_search and pkginfo.pkg_hash.startswith("a"):
+            try:
+                return _apt._apt_cache[pkginfo.name].candidate.description
+            except Exception:
+                pass
+
+        comp = self._get_backend_component(pkginfo)
+
+        return pkginfo.get_description(comp)
+
+    def get_icon(self, pkginfo):
+        """
+        Returns the icon name (or path) to display for the package
+        """
+        comp = self._get_backend_component(pkginfo)
+
+        return pkginfo.get_icon(comp)
+
+    def get_screenshots(self, pkginfo):
+        """
+        Returns a list of screenshot urls
+        """
+        comp = self._get_backend_component(pkginfo)
+
+        return pkginfo.get_screenshots(comp)
+
+    def get_version(self, pkginfo):
+        """
+        Returns the current version string, if available
+        """
+        comp = self._get_backend_component(pkginfo)
+
+        return pkginfo.get_version(comp)
+
+    def get_url(self, pkginfo):
+        """
+        Returns the home page url for a package.  If there is
+        no url for the package, in the case of flatpak, the remote's url
+        is displayed instead
+        """
+        comp = self._get_backend_component(pkginfo)
+
+        return pkginfo.get_url(comp)
+
+    def is_busy(self):
+        return len(self.tasks.keys()) > 0
+
+    def get_task_count(self):
+        return len(self.tasks.keys())
+
+    def get_active_pkginfos(self):
+        pkginfos = []
+
+        for pkg_hash in self.tasks.keys():
+            pkginfos.append(self.tasks[pkg_hash].pkginfo)
+
+        return pkginfos
+
+    def task_running(self, task):
+        """
+        Returns whether a given task is currently executing.
+        """
+        return task.pkginfo.pkg_hash in self.tasks.keys()
+
+    def execute_task(self, task, client_finished_cb, client_progress_cb=None):
+        """
+        Executes a given task.  The client_finished_cb is required always, to notify
+        when the task completes. The progress and error callbacks are optional.  If
+        they're left out, a standalone progress window is created to allow the user to
+        see the task's progress (and cancel it if desired.)
+        """
+        self.tasks[task.pkginfo.pkg_hash] = task
+        print("Starting task for package %s, type '%s'" % (task.pkginfo.pkg_hash, task.type))
+
+        task.client_finished_cb = client_finished_cb
+        task.client_progress_cb = client_progress_cb
+
+        task.finished_cleanup_cb = self._task_finished
+        task.error_cleanup_cb = self._task_error
+
+        task.execute(task)
+
+    def _task_finished(self, task):
+        print("Done with task (success)", task.pkginfo.pkg_hash)
+        del self.tasks[task.pkginfo.pkg_hash]
+
+        self._post_task_update(task)
+
+    def _task_error(self, task):
+        print("Done with task (error)", task.pkginfo.pkg_hash)
+        del self.tasks[task.pkginfo.pkg_hash]
+
+        self._post_task_update(task)
+
+    def _post_task_update(self, task):
+        if task.pkginfo.pkg_hash.startswith("a"):
+            thread = threading.Thread(target=self._apt_post_task_update_thread, args=(task,))
+            thread.start()
+        else:
+            self._run_client_callback(task)
+
+    def _apt_post_task_update_thread(self, task):
+        _apt.sync_cache_installed_states()
+
+        # This needs to be called after reloading the apt cache, otherwise our installed
+        # apps don't update correctly
+        self._run_client_callback(task)
+
+    def _run_client_callback(self, task):
+        GObject.idle_add(task.client_finished_cb, task.pkginfo, task.error_message)
+
+def interact():
+    import readline
+    import code
+    variables = globals().copy()
+    variables.update(locals())
+    shell = code.InteractiveConsole(variables)
+    shell.interact()
+
+# Debugging - you can run installer.py on its own, and test things with the Installer (i)
+
+if __name__ == "__main__":
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+
+    i = Installer()
+    i.init(ready_callback=interact)
+
+    ml = GLib.MainLoop.new(None, True)
+    ml.run()

--- a/usr/lib/python3/dist-packages/mintcommon/installer/misc.py
+++ b/usr/lib/python3/dist-packages/mintcommon/installer/misc.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python3
+
+import os
+import time
+
+DEBUG_MODE = os.getenv("MINTINSTALL_DEBUG", False)
+
+# Used as a decorator to time functions
+def print_timing(func):
+    if not DEBUG_MODE:
+        return func
+    else:
+        def wrapper(*arg):
+            t1 = time.time()
+            res = func(*arg)
+            t2 = time.time()
+            print('%s took %0.3f ms' % (func.__qualname__, (t2 - t1) * 1000.0))
+            return res
+        return wrapper
+
+def debug(str):
+    if not DEBUG_MODE:
+        return
+    print("Mintinstall (DEBUG): %s" % str)

--- a/usr/lib/python3/dist-packages/mintcommon/installer/pkgInfo.py
+++ b/usr/lib/python3/dist-packages/mintcommon/installer/pkgInfo.py
@@ -1,0 +1,333 @@
+import sys
+if sys.version_info.major < 3:
+    raise "python3 required"
+
+from gi.repository import AppStream
+
+def capitalize(string):
+    if string and len(string) > 1:
+        return (string[0].upper() + string[1:])
+    else:
+        return (string)
+
+class PkgInfo:
+    __slots__ = "pkg_hash", "name", "display_name", "summary", "description",    \
+                "icon", "screenshots", "url", "version", "categories", "refid",  \
+                "remote", "remote_url", "kind", "arch", "branch", "commit"
+
+    def __init__(self, pkg_hash):
+        # Saved stuff
+        self.pkg_hash = pkg_hash
+        self.name = None
+        # some flatpak-specific things
+        self.refid=""
+        self.remote = ""
+        self.kind = 0
+        self.arch = ""
+        self.branch = ""
+        self.commit = ""
+        self.remote_url = ""
+
+        # Display info fetched by methods always
+        self.display_name = None
+        self.summary = None
+        self.description = None
+        self.version = None
+        self.icon = None
+        self.screenshots = []
+        self.url = None
+
+        # Runtime categories
+        self.categories = []
+
+    def __getstate__(self):
+        return (                                 \
+        self.pkg_hash,       self.name,          \
+        self.remote,         self.remote_url,    \
+        self.kind,           self.arch,          \
+        self.branch,         self.commit,        \
+        self.refid                               \
+        )
+
+    def __setstate__(self, state):
+        self.pkg_hash,       self.name,          \
+        self.remote,         self.remote_url,    \
+        self.kind,           self.arch,          \
+        self.branch,         self.commit,        \
+        self.refid                               = state
+
+        self.categories = []
+        self.clear_cached_info()
+
+    def clear_cached_info(self):
+        self.display_name = None
+        self.summary = None
+        self.description = None
+        self.icon = None
+        self.screenshots = []
+        self.version = None
+        self.url = None
+
+class AptPkgInfo(PkgInfo):
+    def __init__(self, pkg_hash, apt_pkg):
+        super(AptPkgInfo, self).__init__(pkg_hash)
+        self.name = apt_pkg.name
+
+    def get_display_name(self, apt_pkg=None):
+        # fastest
+        if self.display_name:
+            return self.display_name
+
+        if apt_pkg:
+            self.display_name = apt_pkg.name.capitalize()
+
+        if not self.display_name:
+            self.display_name = self.name.capitalize()
+
+        self.display_name = self.display_name.replace(":i386", "")
+
+        return self.display_name
+
+    def get_summary(self, apt_pkg=None):
+        # fastest
+        if self.summary:
+            return self.summary
+
+        if apt_pkg and apt_pkg.candidate:
+            candidate = apt_pkg.candidate
+
+            summary = ""
+            if candidate.summary is not None:
+                summary = candidate.summary
+                summary = summary.replace("<", "&lt;")
+                summary = summary.replace("&", "&amp;")
+
+                self.summary = capitalize(summary)
+
+        if self.summary == None:
+            self.summary = ""
+
+        return self.summary
+
+    def get_description(self, apt_pkg=None):
+        # fastest
+        if self.description:
+            return self.description
+
+        if apt_pkg and apt_pkg.candidate:
+            candidate = apt_pkg.candidate
+
+            description = ""
+            if candidate.description != None:
+                description = candidate.description
+                description = description.replace("<p>", "").replace("</p>", "\n")
+                for tags in ["<ul>", "</ul>", "<li>", "</li>"]:
+                    description = description.replace(tags, "")
+
+                self.description = capitalize(description)
+
+        if self.description == None:
+            self.description = ""
+
+        return self.description
+
+    def get_icon(self, apt_pkg=None):
+        return None # this is handled in mintinstall directly for now
+
+    def get_screenshots(self, apt_pkg=None):
+        return [] # handled in mintinstall for now
+
+    def get_version(self, apt_pkg=None):
+        if self.version:
+            return self.version
+
+        if apt_pkg:
+            if apt_pkg.is_installed:
+                self.version = apt_pkg.installed.version
+            else:
+                self.version = apt_pkg.candidate.version
+
+            if self.version == None:
+                self.version = ""
+
+        return self.version
+
+    def get_url(self, apt_pkg=None):
+        if self.url:
+            return self.url
+
+        if apt_pkg:
+            if apt_pkg.is_installed:
+                self.url = apt_pkg.installed.homepage
+            else:
+                self.url = apt_pkg.candidate.homepage
+
+        if self.url == None:
+            self.url = ""
+
+        return self.url
+
+
+class FlatpakPkgInfo(PkgInfo):
+    def __init__(self, pkg_hash, remote, ref, remote_url, installed):
+        super(FlatpakPkgInfo, self).__init__(pkg_hash)
+
+        self.name = ref.get_name() # org.foo.Bar
+        self.remote = remote # "flathub"
+        self.remote_url = remote_url
+
+        self.refid = ref.format_ref() # app/org.foo.Bar/x86_64/stable
+        self.kind = ref.get_kind() # Will be app for now
+        self.arch = ref.get_arch()
+        self.branch = ref.get_branch()
+        self.commit = ref.get_commit()
+
+    def get_display_name(self, as_component=None):
+        # fastest
+        if self.display_name:
+            return self.display_name
+
+        if as_component:
+            display_name = as_component.get_name()
+
+            if display_name != None:
+                self.display_name = capitalize(display_name)
+
+        if self.display_name == None:
+            self.display_name = self.name
+
+        return self.display_name
+
+    def get_summary(self, as_component=None):
+        # fastest
+        if self.summary:
+            return self.summary
+
+        if as_component:
+            summary = as_component.get_summary()
+
+            if summary != None:
+                self.summary = summary
+
+        if self.summary == None:
+            self.summary = ""
+
+        return self.summary
+
+    def get_description(self, as_component=None):
+        # fastest
+        if self.description:
+            return self.description
+
+        if as_component:
+            description = as_component.get_description()
+
+            if description != None:
+                description = description.replace("<p>", "").replace("</p>", "\n")
+                for tags in ["<ul>", "</ul>", "<li>", "</li>"]:
+                    description = description.replace(tags, "")
+                self.description = capitalize(description)
+
+        if self.description == None:
+            self.description = ""
+
+        return self.description
+
+    def get_icon(self, as_component=None):
+        if self.icon:
+            return self.icon
+
+        if as_component:
+            icons = as_component.get_icons()
+
+            if icons:
+                if icons[0].get_kind() == AppStream.IconKind.LOCAL:
+                    self.icon = icons[0].get_filename()
+                elif icons[0].get_kind() == AppStream.IconKind.STOCK:
+                    self.icon = icons[0].get_name()
+
+        if self.icon == None:
+            self.icon = self.name
+
+        return self.icon
+
+    def get_screenshots(self, as_component=None):
+        if len(self.screenshots) > 0:
+            return self.screenshots
+
+        if as_component:
+            screenshots = as_component.get_screenshots()
+
+            for ss in screenshots:
+                images = ss.get_images()
+
+                if len(images) == 0:
+                    continue
+
+                # FIXME: there must be a better way.  Finding an optimal size to use without just
+                # resorting to an original source.
+
+                best = None
+                largest = None
+
+                for image in images:
+                    if image.get_kind() == AppStream.ImageKind.SOURCE:
+                        continue
+
+                    w = image.get_width()
+
+                    if w > 500 and w < 625:
+                        best = image
+                        break
+
+                    if w > 625:
+                        continue
+
+                    if largest == None or (largest != None and largest.get_width() < w):
+                        largest = image
+
+                if best == None and largest == None:
+                    continue
+
+                if best == None:
+                    best = largest
+
+                if ss.get_kind() == AppStream.ScreenshotKind.DEFAULT:
+                    self.screenshots.insert(0, best.get_url())
+                else:
+                    self.screenshots.append(best.get_url())
+
+        return self.screenshots
+
+    def get_version(self, as_component=None):
+        if self.version:
+            return self.version
+
+        if as_component:
+            releases = as_component.get_releases()
+
+            if len(releases) > 0:
+                version = releases[0].get_version()
+
+                if version:
+                    self.version = version
+
+        if self.version == None:
+            self.version = ""
+
+        return self.version
+
+    def get_url(self, as_component=None):
+        if self.url:
+            return self.url
+
+        if as_component:
+            url = as_component.get_url(AppStream.UrlKind.HOMEPAGE)
+
+            if url != None:
+                self.url = url
+
+        if self.url == None:
+            self.url = self.remote_url
+
+        return self.url


### PR DESCRIPTION
- structure reworked, all content is now in optional sub-modules
- additional modules can easily be added in the future (further PR incoming)
- moved mintinstall's installer module here
- installer module amended with functionality to generate the list of installed applications to be shared by mintinstall and mintbackup (see related pull requests as well as the original closed one here: https://github.com/linuxmint/mintinstall/pull/216)
  - that last part only supports ubiquity's installer log. I don't know of a way to accomplish this on LMDE3, I am not aware of that installer keeping a log of what it installed, so we'd have to hardcode the manifest to do the same thing.
- converted python2 scripts to python3

This must be released as **version >= 2** as per the related pull requests' control files.