### PR TITLE
Resolve to STATUS_FORBIDDEN when simulating removal of Priority:required packages.

### DIFF
--- a/usr/lib/python3/dist-packages/mintcommon/installer/_apt.py
+++ b/usr/lib/python3/dist-packages/mintcommon/installer/_apt.py
@@ -206,6 +206,7 @@ class MetaTransaction(packagekit.Task):
     def on_transaction_error(self, error):
         # PkErrorEnums are sent from the backend mainly
         # PkClientErrors are related to interaction with a task/client - accept/deny, etc...
+        apt_cache = get_apt_cache()
         if error.code == packagekit.ClientError.DECLINED_SIMULATION:
             # canceled via additional-changes dialog
             return
@@ -224,7 +225,7 @@ class MetaTransaction(packagekit.Task):
             # user navigated away before simulation was complete, etc...
             return
 
-        if real_code == packagekit.ErrorEnum.CANNOT_REMOVE_SYSTEM_PACKAGE or self.task.pkginfo.name in CRITICAL_PACKAGES:
+        if real_code == packagekit.ErrorEnum.CANNOT_REMOVE_SYSTEM_PACKAGE or self._is_critical_package(apt_cache[self.task.pkginfo.name]):
             self.task.info_ready_status = self.task.STATUS_FORBIDDEN
 
         if self.task.info_ready_status == self.task.STATUS_NONE:


### PR DESCRIPTION
# Related Issue

https://github.com/linuxmint/mintinstall/issues/488

# Before

<img width="795" height="727" alt="before_dep_fix" src="https://github.com/user-attachments/assets/4089cb61-f993-45ae-a5bf-7e2642931b63" />


In mintinstall,  going to the package page for a package that is both

* priority:  "required"  
* essential: no

would show an error pop-up. An example package is zlib1g. This was a result of the following:

1.  The package would simulate being removed 
2.  During that  removal simulation, an "unmet dependencies" error would be thrown which would resolve to status BROKEN.
3. This would ultimately result in the error pop-up window. 



# After

<img width="1062" height="864" alt="after_dep_fix" src="https://github.com/user-attachments/assets/e01640d5-0986-4513-a712-b506eea0d0fe" />


We change the removal simulation to resolve to STATUS_FORBIDDEN  [for Priority:required packages](https://github.com/linuxmint/mintcommon/blob/dc9c197a3ee028fea92e75564d7924b7a256855f/usr/lib/python3/dist-packages/mintcommon/installer/_apt.py#L350). In mintinstall, these packages now show no error pop up and the remove button is greyed out with "Cannot Remove" message, along with detailed tooltip message that removing the package would cause damage to the system. . 



